### PR TITLE
Добавить линтеры в CI (#6)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,56 @@
+name: Lint
+run-name: Lint commit "${{ github.sha }}"
+
+on: push
+jobs:
+  mypy:
+    name: Mypy
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Build mypy
+        run: docker compose --file envs/ci/docker-compose.yml build mypy
+
+      - name: Run mypy
+        run: docker compose --file envs/ci/docker-compose.yml run mypy
+
+  ruff:
+    name: Ruff
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Build ruff
+        run: docker compose --file envs/ci/docker-compose.yml build ruff
+
+      - name: Run ruff
+        run: docker compose --file envs/ci/docker-compose.yml run ruff
+
+  flake8:
+    name: Flake8
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Build flake8
+        run: docker compose --file envs/ci/docker-compose.yml build flake8
+
+      - name: Run flake8
+        run: docker compose --file envs/ci/docker-compose.yml run flake8
+
+  pylint:
+    name: Pylint
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Build pylint
+        run: docker compose --file envs/ci/docker-compose.yml build pylint
+
+      - name: Run pylint
+        run: docker compose --file envs/ci/docker-compose.yml run pylint

--- a/envs/ci/Dockerfile
+++ b/envs/ci/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+    # we need 'enchant-2' for pylint's spellchecker
+    && apt-get -y install enchant-2 \
+    && pip install --upgrade pip \
+    && pip install poetry==1.4.2
+
+RUN poetry config virtualenvs.create false
+
+COPY poetry.lock pyproject.toml ./
+
+RUN poetry install --with=dev
+
+COPY . ./

--- a/envs/ci/docker-compose.yml
+++ b/envs/ci/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.8"
+
+services:
+  app-build: &app-build
+    build:
+      context: ../..  # path from the corrent file to the project root dir
+      dockerfile: envs/ci/Dockerfile  # path from the project root dir to the Dockerfile
+
+  mypy:
+    <<: *app-build
+    entrypoint: mypy
+
+  ruff:
+    <<: *app-build
+    entrypoint: ruff check src
+
+  flake8:
+    <<: *app-build
+    entrypoint: flake8
+  
+  pylint:
+    <<: *app-build
+    entrypoint: pylint src


### PR DESCRIPTION
После того как мы добавили и настроили линтеры (#5), необходимо сразу настроить CI пайплайн, чтобы все последующие мр-ы проходили через CI.

Для настройки CI было решено использовать GitHub Actions. Но при этом сделать контейнеризованное решение, для того чтобы как можно меньше зависеть от откружения GitHub Actions и всегда иметь возможность сменить CI систему не испытывая больших трудностей.

GitHub Actions предоставляет альтернативу контейнерам - каждый воркфлоу (он же пайплайн) на гитхабе выполняется в их контейнерах на их операционных системах (так называемых раннерах). С этим довольно удобно работать и это избавляет от многих проблем, но в таком случае для переноса нашего пайплайна на другой движок (например Jenkins или TravisCI), который предполагает наличие контейнеризованного решения, у нас могут начаться трудности. Также мы не можем быть на сто процентов уверены в том, что окружение, в котором прогоняются наши пайплайны на гитхабе полностью совпадает с окружением, в котором код будет работать на проде.

Исходя из это хотелось бы использовать свои контейнеры внутри окружения GitHub Actions. В таком случае нам необходимо будет решить только одно проблему - кэширование наших докер контейнеров силами гитхаба, но эта проблема будет решаться в рамках другой задачи.

Линтеры необходимо запускать параллельно. Для этого мы будем запускать каждый линтер в отдельной джобе одного воркфлоу.

Так же необходимо отделить шаг сборки контейнера от шага непосредвенного запуска контейнера, чтобы логи сборки не попадали в логи самого линтера.

В рамках текущей задачи необходимо:
- в папку `envs/ci` добавить `Dockerfile` и `docker-compose.yml` для запуска линтеров на CI
- в папку `.github/workflows` добавить `lint.yml` воркфлоу каджый линтер должен запускаться в отдельной джобе каждый линтер должен запускаться в контейнере из `envs/ci/docker-compose.yml`