### PR TITLE
Добавить юнит-тесты в CI (#15)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+run-name: Test commit "${{ github.sha }}"
+
+on: push
+jobs:
+  pytest:
+    name: Pytest
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Build pytest
+        run: docker compose --file envs/ci/docker-compose.yml build pytest
+
+      - name: Run pytest
+        run: docker compose --file envs/ci/docker-compose.yml run pytest

--- a/envs/ci/docker-compose.yml
+++ b/envs/ci/docker-compose.yml
@@ -21,3 +21,7 @@ services:
   pylint:
     <<: *app-build
     entrypoint: pylint src
+
+  pytest:
+    <<: *app-build
+    entrypoint: pytest --cov=src


### PR DESCRIPTION
После того как мы настроили окружение для юнит-тестов (#14), необходимо сразу добавить их в CI-пайплайн, чтобы все последующие мр-ы проходили тесты через CI.

В рамках этой задачи необходимо:

- добавить сервис для запуска pytest в `envs/ci/docker-compose.yml`
- добавить новый воркфлоу `.github/workflows/test.yml`, который будет запускать пайтест по аналогии с запуском линтеров в `.github/workflows/lint.yml`