### PR TITLE
Добавить кэш докера в CI (#17)

### DIFF
--- a/.github/actions/docker/update-buildx-cache/action.yml
+++ b/.github/actions/docker/update-buildx-cache/action.yml
@@ -1,0 +1,19 @@
+# This ugly but it's necessary if you don't want your cache to grow forever
+# until it hits GitHub's limit of 5GB. Because `cache_to` option does not
+# update the entire Docker cache, but just adds some new layers.
+# This is a temporary fix. You can read more about this problem here:
+# https://github.com/docker/build-push-action/issues/252
+# https://github.com/moby/buildkit/issues/1896
+
+name: Update buildx cache
+description: Updates buildx cache correctly to prevent GitHub cache grow forever
+
+runs:
+  using: composite
+  steps:
+    - name: Update buildx cache
+      shell: bash
+      run: |
+        set -o allexport; source envs/ci/.env; set +o allexport;  # export environment variables from dotenv file
+        rm -rf ${BUILDX_CACHE_SRC}
+        mv ${BUILDX_CACHE_DEST} ${BUILDX_CACHE_SRC}

--- a/.github/actions/docker/use-buildx-cache/action.yml
+++ b/.github/actions/docker/use-buildx-cache/action.yml
@@ -1,0 +1,17 @@
+name: Use buildx cache
+description: Shortcut for several reusable steps which allow to get/put Docker cache from/in GitHub Cache
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: buildx-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+        restore-keys: |
+          buildx-${{ runner.os }}-${{ github.ref_name }}
+          buildx-${{ runner.os }}-${{ github.event.repository.default_branch }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,11 +10,17 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
+      - name: Cache Docker layers
+        uses: ./.github/actions/docker/use-buildx-cache
+
       - name: Build mypy
         run: docker compose --file envs/ci/docker-compose.yml build mypy
 
       - name: Run mypy
         run: docker compose --file envs/ci/docker-compose.yml run mypy
+
+      - name: Update buildx cache
+        uses: ./.github/actions/docker/update-buildx-cache
 
   ruff:
     name: Ruff
@@ -23,11 +29,17 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
+      - name: Cache Docker layers
+        uses: ./.github/actions/docker/use-buildx-cache
+
       - name: Build ruff
         run: docker compose --file envs/ci/docker-compose.yml build ruff
 
       - name: Run ruff
         run: docker compose --file envs/ci/docker-compose.yml run ruff
+
+      - name: Update buildx cache
+        uses: ./.github/actions/docker/update-buildx-cache
 
   flake8:
     name: Flake8
@@ -36,11 +48,17 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
+      - name: Cache Docker layers
+        uses: ./.github/actions/docker/use-buildx-cache
+
       - name: Build flake8
         run: docker compose --file envs/ci/docker-compose.yml build flake8
 
       - name: Run flake8
         run: docker compose --file envs/ci/docker-compose.yml run flake8
+
+      - name: Update buildx cache
+        uses: ./.github/actions/docker/update-buildx-cache
 
   pylint:
     name: Pylint
@@ -49,8 +67,14 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
+      - name: Cache Docker layers
+        uses: ./.github/actions/docker/use-buildx-cache
+
       - name: Build pylint
         run: docker compose --file envs/ci/docker-compose.yml build pylint
 
       - name: Run pylint
         run: docker compose --file envs/ci/docker-compose.yml run pylint
+
+      - name: Update buildx cache
+        uses: ./.github/actions/docker/update-buildx-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,14 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
+      - name: Cache Docker layers
+        uses: ./.github/actions/docker/use-buildx-cache
+
       - name: Build pytest
         run: docker compose --file envs/ci/docker-compose.yml build pytest
 
       - name: Run pytest
         run: docker compose --file envs/ci/docker-compose.yml run pytest
+
+      - name: Update buildx cache
+        uses: ./.github/actions/docker/update-buildx-cache

--- a/envs/ci/.env
+++ b/envs/ci/.env
@@ -1,0 +1,2 @@
+BUILDX_CACHE_DEST="/tmp/.buildx-cache-new"
+BUILDX_CACHE_SRC="/tmp/.buildx-cache"

--- a/envs/ci/docker-compose.yml
+++ b/envs/ci/docker-compose.yml
@@ -5,6 +5,10 @@ services:
     build:
       context: ../..  # path from the corrent file to the project root dir
       dockerfile: envs/ci/Dockerfile  # path from the project root dir to the Dockerfile
+      cache_from:
+        - type=local,src=${BUILDX_CACHE_SRC}
+      cache_to:
+        - type=local,dest=${BUILDX_CACHE_DEST}
 
   mypy:
     <<: *app-build


### PR DESCRIPTION
После того как мы добавили линтеры и тестирование в CI (#6, #16), нам необходимо добавить кэширование для сборок докера. На данный момент наш CI пайплайн собирает докер образы заново при каждом запуске. Это занимает какое-то время и мы хотели бы ускорить этот процесс. Мы должни добавить кэширование сборок докера, чтобы предотвратить пересборку образов - каждая новая сборка образа будет использовать кэш из предыдущих сборок.

GitHub Actions позволяет нам кэшировать файлы находящиеся по определенному пути на раннере с помощью [cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#using-the-cache-action) экшена. Это значит, что наша задача сводится к одной проблеме - как положить кэш докера в конкретную папку с конкретным путём на хост машине, а также как использовать его из этой папки для последующих сборок.

Поскольку мы запускаем наши контейнеры через `docker-compose`, нам нужно решение, которое работает именно через `docker-compose`, а не через `docker`.

В docker-compose файле в секции `build` можно использовать две опции `cache_to` и `cache_from` ([дока](https://docs.docker.com/compose/compose-file/build/#cache_from)). Эти опции поддерживаются только новым билдером докера - `buildx`. `buildx` встроен во вторую версию docker-compose. К счастью второй компоуз установлен на раннерах гитхаба. Чтобы вызывать компоуз второй версии, нужно вызывать его без дефиса: `docker compose`.

Чтобы установить `buildx` в качестве билдера для докера на GitHub, можно воспользоваться [setup-buildx-action](https://github.com/docker/setup-buildx-action).

В рамках этой задачи необходимо добавить кэширование слоёв сборки докера в GitHub Actions Cache.