### PR TITLE
Поправить линтинг тестов (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ flake8
 
 4. Pylint.
 ```bash
-pylint src
+pylint src tests
 ```
 
 

--- a/envs/ci/docker-compose.yml
+++ b/envs/ci/docker-compose.yml
@@ -16,15 +16,15 @@ services:
 
   ruff:
     <<: *app-build
-    entrypoint: ruff check src
+    entrypoint: ruff check src tests
 
   flake8:
     <<: *app-build
     entrypoint: flake8
-  
+
   pylint:
     <<: *app-build
-    entrypoint: pylint src
+    entrypoint: pylint src tests
 
   pytest:
     <<: *app-build


### PR DESCRIPTION
Во время работы над настройкой окружения для юнит-тестов (#13), мы добавили линтинг кода тестов в рафф для локальной разработки. Т.е. добавили папку `tests` в команду запуска раффа в `README.md`:

> 2. Ruff.
> ```bash
> ruff check src tests
> ```

Но при этом забыли обновить команду в `envs/ci/docker-compose.yml`:
```yml
ruff:
  <<: *app-build
  entrypoint: ruff check src
```

***

Похожая ситуация произошла и с пайлинтом, но пайлинт мы забыли обновить не только в `envs/ci/docker-compose.yml`, но и в `README.md`.

В рамках этой задачи необходимо добавить папку `tests` в команду запуска раффа и пайлинта на CI в файле `envs/ci/docker-compose.yml`. А также добавить папку `tests` в команду запуска пайлинта в `README.md`.