### PR TITLE
Ускорить линтеры на CI (#22)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,15 @@ jobs:
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
 
+      - name: Cache mypy
+        uses: actions/cache@v3
+        with:
+          path: ./.mypy_cache
+          key: mypy-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            mypy-${{ runner.os }}-${{ github.ref_name }}
+            mypy-${{ runner.os }}-${{ github.event.repository.default_branch }}
+
       - name: Build mypy
         run: docker compose --file envs/ci/docker-compose.yml build mypy
 
@@ -31,6 +40,15 @@ jobs:
 
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
+
+      - name: Cache ruff
+        uses: actions/cache@v3
+        with:
+          path: ./.ruff_cache
+          key: ruff-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            ruff-${{ runner.os }}-${{ github.ref_name }}
+            ruff-${{ runner.os }}-${{ github.event.repository.default_branch }}
 
       - name: Build ruff
         run: docker compose --file envs/ci/docker-compose.yml build ruff

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,15 @@ jobs:
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
 
+      - name: Cache pytest
+        uses: actions/cache@v3
+        with:
+          path: ./.pytest_cache
+          key: pytest-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            pytest-${{ runner.os }}-${{ github.ref_name }}
+            pytest-${{ runner.os }}-${{ github.event.repository.default_branch }}
+
       - name: Build pytest
         run: docker compose --file envs/ci/docker-compose.yml build pytest
 

--- a/envs/ci/docker-compose.yml
+++ b/envs/ci/docker-compose.yml
@@ -12,10 +12,16 @@ services:
 
   mypy:
     <<: *app-build
+    volumes:
+      # bind .mypy_cache to the host in order to store mypy cache in GitHub Cache
+      - ../../.mypy_cache:/app/.mypy_cache  # host path is relative to the current docker-compose file
     entrypoint: mypy
 
   ruff:
     <<: *app-build
+    volumes:
+      # bind .ruff_cache to the host in order to store ruff cache in GitHub Cache
+      - ../../.ruff_cache:/app/.ruff_cache  # host path is relative to the current docker-compose file
     entrypoint: ruff check src tests
 
   flake8:
@@ -24,8 +30,11 @@ services:
 
   pylint:
     <<: *app-build
-    entrypoint: pylint src tests
+    entrypoint: pylint --jobs=0 src tests
 
   pytest:
     <<: *app-build
+    volumes:
+      # bind .pytest_cache to the host in order to store pytest cache in GitHub Cache
+      - ../../.pytest_cache:/app/.pytest_cache  # host path is relative to the current docker-compose file
     entrypoint: pytest --cov=src


### PR DESCRIPTION
Мы можем ускорить работу линтеров и пайтеста на CI. Для майпая, раффа и пайтеста можно добавить кэширование, а для пайлинта увеличить количество процессов.

В рамках этой задачи необходимо:
- добавить сохранение кэша майпая, раффа и пайтеста на GitHub
- добавить запуск на нескольких процессах для пайлинта