### PR TITLE
Поправить отключенные проверки флейка (#25)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,11 +8,157 @@ exclude =
     __pycache__,
 
 ignore =
-    # following line ignores all checks from raw flake8 (pyflakes, pycodestyle and mccabe)
-    # because those are already implemented in ruff and will be checked by ruff since it's much faster
-    E, F, W, C90,
+    # options below are ignored because they are already implemented in ruff
+    # if you want to ignored another error for some reason, please do it in a separate section above
+    # =========
+    # Pyflakes
+    # =========
+ 	# {name} imported but unused; consider using importlib.util.find_spec to test for availability
+    F401,
+ 	# Import {name} from line {line} shadowed by loop variable
+    F402,
+ 	# from {name} import * used; unable to detect undefined names
+    F403,
+ 	# from __future__ imports must occur at the beginning of the file
+    F404,
+ 	# {name} may be undefined, or defined from star imports:
+    F405,
+ 	# from {name} import * only allowed at module level
+    F406,
+ 	# Future feature {name} is not defined
+    F407,
+    # %-format string has invalid format string:
+    F501,
+    # %-format string expected mapping but got sequence
+    F502,
+    # %-format string expected sequence but got mapping
+    F503,
+    # %-format string has unused named argument(s):
+    F504,
+    # %-format string is missing argument(s) for placeholder(s):
+    F505,
+    # %-format string has mixed positional and named placeholders
+    F506,
+    # %-format string has {wanted} placeholder(s) but {got} substitution(s)
+    F507,
+    # %-format string * specifier requires sequence
+    F508,
+    # %-format string has unsupported format character {char}
+    F509,
+    # .format call has invalid format string:
+    F521,
+    # .format call has unused named argument(s):
+    F522,
+    # .format call has unused arguments at position(s):
+    F523,
+    # .format call is missing argument(s) for placeholder(s):
+    F524,
+    # .format string mixes automatic and manual numbering
+    F525,
+    # f-string without any placeholders
+    F541,
+    # Dictionary key literal {name} repeated
+    F601,
+    # Dictionary key {name} repeated
+    F602,
+    # Too many expressions in star-unpacking assignment
+    F621,
+    # Two starred expressions in assignment
+    F622,
+    # Assert test is a non-empty tuple, which is always True
+    F631,
+    # Use == to compare constant literals
+    F632,
+    # Use of >> is invalid with print function
+    F633,
+    # If test is a tuple, which is always True
+    F634,
+    # break outside loop
+    F701,
+    # continue not properly in loop
+    F702,
+    # {keyword} statement outside of a function
+    F704,
+    # return statement outside of a function/method
+    F706,
+    # An except block as not the last exception handler
+    F707,
+    # Syntax error in forward annotation: {body}
+    F722,
+    # Redefinition of unused {name} from line
+    F811,
+    # Undefined name {name}
+    F821,
+    # Undefined name {name} in __all__
+    F822,
+    # Local variable {name} referenced before assignment
+    F823,
+    # Local variable {name} is assigned to but never used
+    F841,
+    # Local variable {name} is annotated but never used
+    F842,
+    # raise NotImplemented should be raise NotImplementedError
+    F901,
+    # ===========
+    # pycodestyle
+    # ===========
+    # Indentation contains mixed spaces and tabs
+    E101,
+    # Multiple imports on one line
+    E401,
+    # Module level import not at top of file
+    E402,
+    # Line too long ({width} > {limit} characters)
+    E501,
+    # Multiple statements on one line (colon)
+    E701,
+    # Multiple statements on one line (semicolon)
+    E702,
+    # Statement ends with an unnecessary semicolon
+    E703,
+    # Comparison to None should be cond is None
+    E711,
+    # Comparison to True should be cond is True
+    E712,
+    # Test for membership should be not in
+    E713,
+    # Test for object identity should be is not
+    E714,
+    # Do not compare types, use isinstance()
+    E721,
+    # Do not use bare except
+    E722,
+    # Do not assign a lambda expression, use a def
+    E731,
+    # Ambiguous variable name: {name}
+    E741,
+    # Ambiguous class name: {name}
+    E742,
+    # Ambiguous function name: {name}
+    E743,
+    # io-error {message}
+    E902,
+    # SyntaxError:
+    E999,
+    # Indentation contains tabs
+    W191,
+    # Trailing whitespace
+    W291,
+    # No newline at end of file
+    W292,
+    # Blank line contains whitespace
+    W293,
+    # Doc line too long ({width} > {limit} characters)
+    W505,
+    # Invalid escape sequence: \{char}
+    W605,
+    # ======
+    # mccabe
+    # ======
+    # {name} is too complex ({complexity} > {max_complexity})
+    C901,
 
-per-file-ignores = 
+per-file-ignores =
     # files with tests
     tests/*test_*:
         # Missing docstring


### PR DESCRIPTION
Во время работы над добавлением и настройкой линтеров (#5) было принято решение исключить все проверки стандартного флейка. Из [комментария](https://github.com/week-password/wisher-backend/issues/5#issuecomment-1493139135) к тикету:
> Все проверки стандартного флейка (без плагинов) можно отключить, т.к. ruff реализует их все. Флейк необходимо добавить только для того, чтобы иметь возможность работать с его плагинами.

Но как оказалось, рафф реализует не все проверки стандартного флейка, поэтому в конфиге флейка нужно отключить только те проверки, которые перечислены в правилах раффа для [Pyflakes (F)](https://beta.ruff.rs/docs/rules/#pyflakes-f), [pycodestyle (E, W)](https://beta.ruff.rs/docs/rules/#pyflakes-f) и [mccabe (C90)](https://beta.ruff.rs/docs/rules/#mccabe-c90).

В рамках этой задачи необходимо уточнить список `ignore = ` в файле `.flake8`, чтобы отключить только те ошибки, которые действительно реализованы в раффе.

***

PS: Мы могли сначала отключить все ошибки, а потом выборочно включить те, которые не реализованы в раффе. Таким образом список ошибок оказался бы намного меньше, но кроме одного плюса, у этого подхода есть ряд минусов. Во-первых, список реализованных проверок довольно четко описан в доке раффа и его гораздо проще сопостовлять со списком отключенных ошибок, а не включенных (в конфиге флейка). Во вторых, если в новой версии флейка появится какая-то новая проверка, которая еще не реализована в раффе, то наш конфиг по умолчанию её отключит и нам придётся явно включать её.