### PR TITLE
Добавить информацию о запуске приложения в README.md (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ poetry shell
 ```
 
 
+## Run app
+
+To run application you need to do all steps from [First time setup](#first-time-setup) section.
+
+1. Run FastAPI.
+```bash
+uvicorn src.app:app
+```
+
+2. Check health status.
+```bash
+curl --request GET http://localhost:8000/health
+```
+
+
 ## Run linters
 
 To run linters you need to do all steps from [First time setup](#first-time-setup) section.


### PR DESCRIPTION
Во время работы над добавлением FastAPI мы забыли добавить в README.md информацию о том, как запустить приложение локально.

В рамках этой задачи необходимо добавить в README.md раздел "Run app" после раздела "First time setup", в котором описать процесс запуска приложения.