### PR TITLE
Переместить окружение тестов для CI в envs/ci/test (#38)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,10 @@ jobs:
             pytest-${{ runner.os }}-${{ github.event.repository.default_branch }}
 
       - name: Build pytest
-        run: docker compose --file envs/ci/lint/docker-compose.yml build pytest
+        run: docker compose --file envs/ci/test/docker-compose.yml build pytest
 
       - name: Run pytest
-        run: docker compose --file envs/ci/lint/docker-compose.yml run pytest
+        run: docker compose --file envs/ci/test/docker-compose.yml run pytest
 
       - name: Update buildx cache
         uses: ./.github/actions/docker/update-buildx-cache

--- a/envs/ci/lint/docker-compose.yml
+++ b/envs/ci/lint/docker-compose.yml
@@ -31,10 +31,3 @@ services:
   pylint:
     <<: *app-build
     entrypoint: pylint --jobs=0 src tests
-
-  pytest:
-    <<: *app-build
-    volumes:
-      # bind .pytest_cache to the host in order to store pytest cache in GitHub Cache
-      - ../../../.pytest_cache:/app/.pytest_cache  # host path is relative to the current docker-compose file
-    entrypoint: pytest --cov=src

--- a/envs/ci/test/.env
+++ b/envs/ci/test/.env
@@ -1,0 +1,2 @@
+BUILDX_CACHE_DEST="/tmp/.buildx-cache-new"
+BUILDX_CACHE_SRC="/tmp/.buildx-cache"

--- a/envs/ci/test/Dockerfile
+++ b/envs/ci/test/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+    # we need 'enchant-2' for pylint's spellchecker
+    && apt-get -y install enchant-2 \
+    && pip install --upgrade pip \
+    && pip install poetry==1.4.2
+
+RUN poetry config virtualenvs.create false
+
+COPY poetry.lock pyproject.toml ./
+
+RUN poetry install --with=dev
+
+COPY . ./

--- a/envs/ci/test/docker-compose.yml
+++ b/envs/ci/test/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.8"
+
+services:
+  app-build: &app-build
+    build:
+      context: ../../..  # path from the corrent file to the project root dir
+      dockerfile: envs/ci/test/Dockerfile  # path from the project root dir to the Dockerfile
+      cache_from:
+        - type=local,src=${BUILDX_CACHE_SRC}
+      cache_to:
+        - type=local,dest=${BUILDX_CACHE_DEST}
+
+  pytest:
+    <<: *app-build
+    volumes:
+      # bind .pytest_cache to the host in order to store pytest cache in GitHub Cache
+      - ../../../.pytest_cache:/app/.pytest_cache  # host path is relative to the current docker-compose file
+    entrypoint: pytest --cov=src


### PR DESCRIPTION
Т.к. тестам на CI нужно будет конфигурировать много разных дополнительных вещей, которые не нужны линтерам, например, сервисы базы данных и файлового хранилища, то имеет смысл держать эти две конфигурации отдельно.

В рамках этой задачи необходимо переместить конфигурацию тестов для CI из `envs/ci/lint` в `envs/ci/test`.