### PR TITLE
Поправить алфавитный порядок в whitelist.txt (#40)

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,12 +1,11 @@
 # This is a whitelist of allowed words for flake8-spellcheck plugin.
 # IMPORTANT: please keep this list alphabetically sorted by whitelisted words
 
-# Python library 
+# Python library
 anyio
 
 # asynchronous (pylint spellcheck)
 async
-
 
 # Python standart library for asynchronous code (pylint spellcheck)
 asyncio
@@ -14,11 +13,11 @@ asyncio
 # fastapi framework
 fastapi
 
-# Python library for testing (pylint spellcheck)
-pytest
-
 # health check
 healthcheck
+
+# Python library for testing (pylint spellcheck)
+pytest
 
 # source
 src


### PR DESCRIPTION
В процессе добавления фастапи (#21) был немного нарушен алфавитный порядок и форматирование в `whitelist.txt`.

В рамках этой задачи необходимо поправить алфавитный порядок в `whitelist.txt` и убрать лишние пустые строки.