### PR TITLE
Добавить идентификатор проекта (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Wisher backend
+# WLSS backend
+
+Backend application for [Wish List Sharing Service](https://github.com/week-password/wisher).
 
 ***
 

--- a/envs/ci/lint/Dockerfile
+++ b/envs/ci/lint/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 
-WORKDIR /app
+WORKDIR /wlss-backend
 
 RUN apt-get update \
     # we need 'enchant-2' for pylint's spellchecker

--- a/envs/ci/lint/docker-compose.yml
+++ b/envs/ci/lint/docker-compose.yml
@@ -1,5 +1,7 @@
 version: "3.8"
 
+name: wlss-ci-lint
+
 services:
   app-build: &app-build
     build:

--- a/envs/ci/test/docker-compose.yml
+++ b/envs/ci/test/docker-compose.yml
@@ -1,5 +1,7 @@
 version: "3.8"
 
+name: wlss-ci-test
+
 services:
   app-build: &app-build
     build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ authors = [
     "Alexey Tsivunin <alexey.tsivunin@yandex.ru",
 ]
 
-description = "Backend for Wisher application."
+description = "Backend for WLSS application."
 
-name = "wisher-backend"
+name = "wlss-backend"
 
 version = "0.0.0"
 


### PR DESCRIPTION
В результате [обсуждения](https://github.com/week-password/wisher/discussions/19) было принято решение создать уникальный идентификатор проекта, который не будет напрямую привязан к названию проекта. Таким образом это позволит нам уникально обозначать проект в коде и других технических местах, но при этом не испытывать проблем с ребрендингом, т.к. идентификатор меняться не будет.

В рамках данной задачи необходимо по возможности убрать название проекта из всех технических мест, чтобы облегчить возможный ребрендинг и везде использовать идентификатор `wlss`, чтобы увеличить уникальность связанных с проектом вещей. Например докер контейнеров.