### PR TITLE
Поправить ошибку форматирования в README.md (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ WLSS_ENV=local/dev alembic upgrade head
 WLSS_ENV=local/dev uvicorn src.app:app
 ```
 
-# 4. Check health status.
+4. Check health status.
 ```bash
 curl --request GET http://localhost:8000/health
 ```


### PR DESCRIPTION
Во время работы над добавлением PostgreSQL (#29), был случайно добавлен символ заголовка `#` в четвертый пункт раздела "Run app" нашего README.md

В рамках этой задачи необходимо убрать этот символ.