### PR TITLE
Добавить бейджи для линтеров в README.md (#33)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,6 +39,23 @@ jobs:
           ENV_FILE: envs/ci/lint/.env
         uses: ./.github/actions/docker/update-buildx-cache
 
+  mypy-badge:
+    name: Mypy badge
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [mypy]
+    steps:
+      - name: Create mypy badge
+        uses: schneegans/dynamic-badges-action@v1.6.0
+        with:
+          auth: ${{ secrets.WLSS_BADGES_GIST_TOKEN }}
+          gistID: 4fc310fa76bff267f6b9f1c9d00c812b
+          filename: mypy.json
+          label: mypy
+          message: ${{ needs.mypy.result == 'success' && 'passed' || 'failed' }}
+          color: ${{ needs.mypy.result == 'success' && vars.BADGE_COLOR_SUCCESS || vars.BADGE_COLOR_FAILURE }}
+
+
   ruff:
     name: Ruff
     runs-on: ubuntu-22.04
@@ -72,6 +89,22 @@ jobs:
           ENV_FILE: envs/ci/lint/.env
         uses: ./.github/actions/docker/update-buildx-cache
 
+  ruff-badge:
+    name: Ruff badge
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [ruff]
+    steps:
+      - name: Create ruff badge
+        uses: schneegans/dynamic-badges-action@v1.6.0
+        with:
+          auth: ${{ secrets.WLSS_BADGES_GIST_TOKEN }}
+          gistID: 4fc310fa76bff267f6b9f1c9d00c812b
+          filename: ruff.json
+          label: ruff
+          message: ${{ needs.ruff.result == 'success' && 'passed' || 'failed' }}
+          color: ${{ needs.ruff.result == 'success' && vars.BADGE_COLOR_SUCCESS || vars.BADGE_COLOR_FAILURE }}
+
   flake8:
     name: Flake8
     runs-on: ubuntu-22.04
@@ -96,6 +129,22 @@ jobs:
           ENV_FILE: envs/ci/lint/.env
         uses: ./.github/actions/docker/update-buildx-cache
 
+  flake8-badge:
+    name: Flake8 badge
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [flake8]
+    steps:
+      - name: Create flake8 badge
+        uses: schneegans/dynamic-badges-action@v1.6.0
+        with:
+          auth: ${{ secrets.WLSS_BADGES_GIST_TOKEN }}
+          gistID: 4fc310fa76bff267f6b9f1c9d00c812b
+          filename: flake8.json
+          label: flake8
+          message: ${{ needs.flake8.result == 'success' && 'passed' || 'failed' }}
+          color: ${{ needs.flake8.result == 'success' && vars.BADGE_COLOR_SUCCESS || vars.BADGE_COLOR_FAILURE }}
+
   pylint:
     name: Pylint
     runs-on: ubuntu-22.04
@@ -119,6 +168,22 @@ jobs:
         env:
           ENV_FILE: envs/ci/lint/.env
         uses: ./.github/actions/docker/update-buildx-cache
+
+  pylint-badge:
+    name: Pylint badge
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [pylint]
+    steps:
+      - name: Create pylint badge
+        uses: schneegans/dynamic-badges-action@v1.6.0
+        with:
+          auth: ${{ secrets.WLSS_BADGES_GIST_TOKEN }}
+          gistID: 4fc310fa76bff267f6b9f1c9d00c812b
+          filename: pylint.json
+          label: pylint
+          message: ${{ needs.pylint.result == 'success' && 'passed' || 'failed' }}
+          color: ${{ needs.pylint.result == 'success' && vars.BADGE_COLOR_SUCCESS || vars.BADGE_COLOR_FAILURE }}
 
   black:
     name: Black

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,19 @@ jobs:
         env:
           ENV_FILE: envs/ci/test/.env
         uses: ./.github/actions/docker/update-buildx-cache
+
+  pytest-badge:
+    name: Pytest badge
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [pytest]
+    steps:
+      - name: Create pytest badge
+        uses: schneegans/dynamic-badges-action@v1.6.0
+        with:
+          auth: ${{ secrets.WLSS_BADGES_GIST_TOKEN }}
+          gistID: 4fc310fa76bff267f6b9f1c9d00c812b
+          filename: pytest.json
+          label: pytest
+          message: ${{ needs.pytest.result == 'success' && '100%' || 'failed' }}
+          color: ${{ needs.pytest.result == 'success' && vars.BADGE_COLOR_SUCCESS || vars.BADGE_COLOR_FAILURE }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # WLSS backend
 
+![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/birthdaysgift/4fc310fa76bff267f6b9f1c9d00c812b/raw/mypy.json)
+![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/birthdaysgift/4fc310fa76bff267f6b9f1c9d00c812b/raw/ruff.json)
+![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/birthdaysgift/4fc310fa76bff267f6b9f1c9d00c812b/raw/flake8.json)
+![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/birthdaysgift/4fc310fa76bff267f6b9f1c9d00c812b/raw/pylint.json)
+![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/birthdaysgift/4fc310fa76bff267f6b9f1c9d00c812b/raw/pytest.json)
+
 Backend application for [Wish List Sharing Service](https://github.com/week-password/wisher).
 
 ***


### PR DESCRIPTION
Мы хотим отобразить статусы прохождения нашего пайплайна для каждого линтера (и пайтеста) с помощью бейджей в README.md

По результатам ресёрча было найдено три возможных решения:
- [Github](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge) badges проблема этого подхода в том, что гитхаб обновляет бейджи слишком [долго](https://stackoverflow.com/questions/57719605/official-badge-for-github-actions#answer-57836888) (около 10 минут после пуша), а также он позволяет создавать бейдж только для целого воркфлоу, но все наши три линтера находятся в одном воркфлоу и при этом мы хотим отобразить разные бейджи для разных линтеров. Поэтому этот вариант нам не подходит

- [BYOB](https://github.com/marketplace/actions/bring-your-own-badge) action проблема этого подхода в том, что он использует отдельную ветку, чтобы хранить и обновлять данные для бейджей, и нам бы не хотелось иметь лишнюю ветку в графе гита не относящуюся к работе

- [Dynamic Badges](https://github.com/marketplace/actions/dynamic-badges) action обновляет бейджи за 5 минут. Использует приватный GitHub Gist для хранения данных для бейджей а также даёт определенную гибкость в настройке бейджей (например, позволяет установить диапазон цветов для бейджа) - так что этот вариант и будет нашим выбором

В рамках этой задачи необходимо:
_(большинство шагов взяты из [доки](https://github.com/marketplace/actions/dynamic-badges#configuration) Dynamic Badges)_

- создать новый приватный гист, назвать его, например, `flake8.json` и скопировать ID гиста (это длинная цифро-буквенная часть url, по которому находится гист)

- перейти в [github.com/settings/tokens](https://github.com/settings/tokens) и создать новый токен со скоупом прав для работы с гистами

- перейти на страницу Secrets в настройках репозитория (Settings > Secrets > Actions) и добавить этот токен как новый секрет

- добавить шаг создания гиста в воркфлоу:
```yaml
  - name: Create Awesome Badge
    uses: schneegans/dynamic-badges-action@v1.6.0
    with:
      auth: ${{ secrets.GIST_SECRET }}
      gistID: <gist-ID>
      filename: flake8.json
      label: Hello
      message: World
      color: orange
```

- добавить бейдж в README.md с помощью ссылки: ``` ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/<user>/<gist-ID>/raw/flake8.json) ```

- добавить вышеописанный шаг в джобу после каждого линтера и связать их через `needs: [ ... ]`

- настроить этот бейдж, чтобы он запускался всегда вне зависимости от того, отработала джоба с линтером или упала с помощью `if: ${{ always() }}`

- чтобы получить результат работы джобы линтера, необходимо использовать `needs.<job-id>.result в данном случае нас интересует только значение `success`

- т.к. синтаксис для воркфлоу не позволяет использовать тернарные операторы, то можно использовать следующий код, чтобы выбирать разный цвет бейджа в зависимости от состояния джобы с линтером: ```yaml color: ${{ needs.mypy.result == 'success' && '#238636' || '#6b2a2b' }} ``` этот код работает точно так же как это тернарное выражение: ```javascript needs.mypy.result == 'success' ? '#238636' : '#6b2a2b' ```