### PR TITLE
Поправить кавычки в env файлах (#53)

### DIFF
--- a/envs/ci/lint/.env
+++ b/envs/ci/lint/.env
@@ -1,2 +1,8 @@
+# Please keep environment variables alphabetically sorted
+# and use double quotes around the values.
+
+# You can read more why we need to use quotes here:
+# https://stackoverflow.com/a/71538763/8431075
+
 BUILDX_CACHE_DEST="/tmp/.buildx-cache-new"
 BUILDX_CACHE_SRC="/tmp/.buildx-cache"

--- a/envs/ci/test/.env
+++ b/envs/ci/test/.env
@@ -1,11 +1,17 @@
+# Please keep environment variables alphabetically sorted
+# and use double quotes around the values.
+
+# You can read more why we need to use quotes here:
+# https://stackoverflow.com/a/71538763/8431075
+
 BUILDX_CACHE_DEST="/tmp/.buildx-cache-new"
 BUILDX_CACHE_SRC="/tmp/.buildx-cache"
 
-MINIO_HOST=minio
-MINIO_PORT=9000
-MINIO_ROOT_PASSWORD=minioadmin
-MINIO_ROOT_USER=minioadmin
-MINIO_SCHEMA=HTTP
+MINIO_HOST="minio"
+MINIO_PORT="9000"
+MINIO_ROOT_PASSWORD="minioadmin"
+MINIO_ROOT_USER="minioadmin"
+MINIO_SCHEMA="HTTP"
 
 POSTGRES_DB="postgres"
 POSTGRES_HOST="postgres"

--- a/envs/local/dev/.env
+++ b/envs/local/dev/.env
@@ -1,8 +1,14 @@
-MINIO_HOST=localhost
-MINIO_PORT=9000
-MINIO_ROOT_PASSWORD=minioadmin
-MINIO_ROOT_USER=minioadmin
-MINIO_SCHEMA=HTTP
+# Please keep environment variables alphabetically sorted
+# and use double quotes around the values.
+
+# You can read more why we need to use quotes here:
+# https://stackoverflow.com/a/71538763/8431075
+
+MINIO_HOST="localhost"
+MINIO_PORT="9000"
+MINIO_ROOT_PASSWORD="minioadmin"
+MINIO_ROOT_USER="minioadmin"
+MINIO_SCHEMA="HTTP"
 
 POSTGRES_DB="postgres"
 POSTGRES_HOST="localhost"

--- a/envs/local/test/.env
+++ b/envs/local/test/.env
@@ -1,8 +1,14 @@
-MINIO_HOST=localhost
-MINIO_PORT=9010
-MINIO_ROOT_PASSWORD=minioadmin
-MINIO_ROOT_USER=minioadmin
-MINIO_SCHEMA=HTTP
+# Please keep environment variables alphabetically sorted
+# and use double quotes around the values.
+
+# You can read more why we need to use quotes here:
+# https://stackoverflow.com/a/71538763/8431075
+
+MINIO_HOST="localhost"
+MINIO_PORT="9010"
+MINIO_ROOT_PASSWORD="minioadmin"
+MINIO_ROOT_USER="minioadmin"
+MINIO_SCHEMA="HTTP"
 
 POSTGRES_DB="postgres"
 POSTGRES_HOST="localhost"


### PR DESCRIPTION
Во время работы над добавлением MinIO (#35), мы добавили переменные связанные с minio в .env файлы для каждого окружения, но забыли обернуть значения переменных в кавычки.

Т.к. некоторые значения не парсятся без кавычек (например значения содержащие пробелы) то лучше принять двойные кавычки за стандарт и использовать их для всех значений переменных окружения. Подробнее про парсинг значений переменных окружения из дотенв файлов можно почитать [тут](https://stackoverflow.com/a/71538763/8431075).

В рамках данной задачи необходимо добавить пропущенные кавычки во все .env файлы.