### PR TITLE
Поправить env файл в update-buildx-cache (#57)

### DIFF
--- a/.github/actions/docker/update-buildx-cache/action.yml
+++ b/.github/actions/docker/update-buildx-cache/action.yml
@@ -14,6 +14,6 @@ runs:
     - name: Update buildx cache
       shell: bash
       run: |
-        set -o allexport; source envs/ci/lint/.env; set +o allexport;  # export environment variables from dotenv file
+        set -o allexport; source ${ENV_FILE}; set +o allexport;  # export environment variables from dotenv file
         rm -rf ${BUILDX_CACHE_SRC}
         mv ${BUILDX_CACHE_DEST} ${BUILDX_CACHE_SRC}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,8 @@ jobs:
         run: docker compose --file envs/ci/lint/docker-compose.yml run mypy
 
       - name: Update buildx cache
+        env:
+          ENV_FILE: envs/ci/lint/.env
         uses: ./.github/actions/docker/update-buildx-cache
 
   ruff:
@@ -57,6 +59,8 @@ jobs:
         run: docker compose --file envs/ci/lint/docker-compose.yml run ruff
 
       - name: Update buildx cache
+        env:
+          ENV_FILE: envs/ci/lint/.env
         uses: ./.github/actions/docker/update-buildx-cache
 
   flake8:
@@ -76,6 +80,8 @@ jobs:
         run: docker compose --file envs/ci/lint/docker-compose.yml run flake8
 
       - name: Update buildx cache
+        env:
+          ENV_FILE: envs/ci/lint/.env
         uses: ./.github/actions/docker/update-buildx-cache
 
   pylint:
@@ -95,6 +101,8 @@ jobs:
         run: docker compose --file envs/ci/lint/docker-compose.yml run pylint
 
       - name: Update buildx cache
+        env:
+          ENV_FILE: envs/ci/lint/.env
         uses: ./.github/actions/docker/update-buildx-cache
 
   black:
@@ -114,4 +122,6 @@ jobs:
         run: docker compose --file envs/ci/lint/docker-compose.yml run black
 
       - name: Update buildx cache
+        env:
+          ENV_FILE: envs/ci/lint/.env
         uses: ./.github/actions/docker/update-buildx-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,6 @@ jobs:
         run: docker compose --file envs/ci/test/docker-compose.yml up --attach pytest --exit-code-from pytest
 
       - name: Update buildx cache
+        env:
+          ENV_FILE: envs/ci/test/.env
         uses: ./.github/actions/docker/update-buildx-cache


### PR DESCRIPTION
Во время работы над добавлением кэша докера в CI, мы добавили экшн `.github/actions/docker/update-buildx-cache/action.yml`, который должен обновлять кеш докера. Но в нём была допущена ошибка - в этом экшене был захардкожен путь до `.env` файла, из которого берутся переменные для получения доступа к локальному кэшу.
```yaml
runs:
  using: composite
  steps:
    - name: Update buildx cache
      shell: bash
      run: |
        set -o allexport; source envs/ci/lint/.env; set +o allexport;  # export environment variables from dotenv file
#          проблема здесь ^^^^^^^^^^^^^^^^^^^^^^^^^
        rm -rf ${BUILDX_CACHE_SRC}
        mv ${BUILDX_CACHE_DEST} ${BUILDX_CACHE_SRC}
```

Так как этот экшн используется не только для CI с линтерами, но и для CI с тестами. То для CI с тестами там должен быть другой путь - `envs/ci/test/.env`.

Эта проблема блокирует задачу #55.

В рамках этой задачи необходимо прокинуть переменную окружения с путём до `.env` файла в экшн и использовать её вместо захардкоженого пути.