### PR TITLE
Добавить pylint-pydantic (#60)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -125,6 +125,7 @@ disable =
 
 load-plugins =
     pylint_per_file_ignores,  # This pylint plugin will enable per-file-ignores in your project
+    pylint_pydantic,  # A Pylint plugin to help Pylint understand the Pydantic.
     pylint.extensions.bad_builtin,  # It can be used for finding prohibited used builtins, such as map or filter, for which other alternatives exists.
     pylint.extensions.broad_try_clause,  # Maximum number of statements allowed in a try clause.
     pylint.extensions.check_elif,  # Used when an else statement is immediately followed by an if statement and does not contain statements that would be unrelated to it.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1366,6 +1366,37 @@ files = [
 ]
 
 [[package]]
+name = "pylint-plugin-utils"
+version = "0.8.2"
+description = "Utilities and helpers for writing Pylint plugins"
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "pylint_plugin_utils-0.8.2-py3-none-any.whl", hash = "sha256:ae11664737aa2effbf26f973a9e0b6779ab7106ec0adc5fe104b0907ca04e507"},
+    {file = "pylint_plugin_utils-0.8.2.tar.gz", hash = "sha256:d3cebf68a38ba3fba23a873809155562571386d4c1b03e5b4c4cc26c3eee93e4"},
+]
+
+[package.dependencies]
+pylint = ">=1.7"
+
+[[package]]
+name = "pylint-pydantic"
+version = "0.1.8"
+description = "A Pylint plugin to help Pylint understand the Pydantic"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pylint_pydantic-0.1.8-py3-none-any.whl", hash = "sha256:4033c67e06885115fa3bb16e3b9ce918ac6439a87e9b4d314158e09bc1067ecb"},
+]
+
+[package.dependencies]
+pydantic = "<2.0"
+pylint = ">2.0,<3.0"
+pylint-plugin-utils = "*"
+
+[[package]]
 name = "pytest"
 version = "7.3.0"
 description = "pytest: simple powerful testing with Python"
@@ -2126,4 +2157,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "2f700166b6c9b2221a98899e21d9ce9c5c83937a9ca501e0545f23cd731d55a9"
+content-hash = "9cb073e539e64eb6583ac1c770a2f7ffecf30ab6d2f0006765fa1f3d059944c1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ mypy = "1.2.0"
 pyenchant = "3.2.2"  # needed for pylint's spellchecker
 pylint = "2.17.2"
 pylint-per-file-ignores = "1.2.0"  # A pylint plugin to ignore error codes per file.
+pylint-pydantic = "0.1.8"  # A Pylint plugin to help Pylint understand the Pydantic.
 pytest = "7.3.0"
 pytest-cov = "4.0.0"
 pytest-env = "0.8.1"  # needed to set up default $WLSS_ENV for tests execution

--- a/src/config.py
+++ b/src/config.py
@@ -26,7 +26,7 @@ class Config(BaseSettings):
     POSTGRES_PORT: str
     POSTGRES_USER: str
 
-    class Config:  # pylint: disable=too-few-public-methods
+    class Config:
         """Pydantic's special class to configure pydantic models."""
 
         allow_mutation = False  # app config should be immutable

--- a/src/entity/schemas.py
+++ b/src/entity/schemas.py
@@ -10,7 +10,7 @@ class Entity(BaseModel):
     bucket: str
     key: str
 
-    class Config:  # pylint: disable=too-few-public-methods
+    class Config:
         """Pydantic's special class to configure pydantic models."""
 
         orm_mode = True


### PR DESCRIPTION
Pylint не всегда понимает особенности библиотеки pydantic, например, сейчас в нашем коде pylint даёт ошибку `too-few-public-methods` для моделей pydantic.

Также это нам пригодится для следующей задачи #59, т.к. там мы планируем добавить `@validator` из пайдэнтика. И этот плагин также поможет пайлинту понять этот декоратор.

Чтобы подружить pylint и pydantic можно воспользоваться плагином [pylint-pydantic](https://github.com/fcfangcc/pylint-pydantic).

В рамках этой задачи необходимо добавить pylint-pydantic и убрать ненужные `# pylint: disable` для моделей пайдэнтика.