### PR TITLE
Настроить рафф для проверки type-checking импортов (#62)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -15,6 +15,11 @@ src = ["src"]
 
 [per-file-ignores]
 
+# ignore checks that are raised only when using FastAPI routes
+"src/**/routes.py" = [
+    "TCH",  # Move import into a type-checking block
+]
+
 # files with fixtures
 "tests/**/conftest.py" = [
     "ARG001",  # Unused function argument: {name}
@@ -48,6 +53,24 @@ allow-star-arg-any = true
 extend-immutable-calls = ["fastapi.Depends"]
 
 
+[flake8-type-checking]
+
+# Exempt certain modules from needing to be moved into type-checking blocks.
+exempt-modules = []
+
+# Exempt classes that list any of the enumerated classes
+# as a base class from needing to be moved into type-checking blocks.
+runtime-evaluated-base-classes = [
+    # classes inherited from classes listed below
+    # can contain type definitions which are used at runtime
+    "pydantic.BaseSettings",
+    "src.shared.database.Base",
+]
+
+# Enforce TC001, TC002, and TC003 rules even when valid runtime imports are present for the same module.
+strict = true
+
+
 [isort]
 
 # A list of modules to consider first-party, regardless of whether they
@@ -59,3 +82,6 @@ lines-after-imports = 2
 
 # Order imports by type, which is determined by case, in addition to alphabetically.
 order-by-type = false
+
+# Add the specified import line to all files.
+required-imports = ["from __future__ import annotations"]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,7 @@
 """Main package for all source code."""
 
+from __future__ import annotations
+
 from pathlib import Path
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -1,5 +1,7 @@
 """Main fastapi application."""
 
+from __future__ import annotations
+
 from fastapi import FastAPI
 
 import src.routes

--- a/src/config.py
+++ b/src/config.py
@@ -1,11 +1,17 @@
 """Application configuration stuff."""
 
-from typing import Final
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from pydantic import BaseSettings
 
 from src.shared.environment import load_environment
 from src.shared.types import UrlSchema
+
+
+if TYPE_CHECKING:
+    from typing import Final
 
 
 load_environment()

--- a/src/entity/models.py
+++ b/src/entity/models.py
@@ -1,5 +1,7 @@
 """Entity model."""
 
+from __future__ import annotations
+
 from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column
 

--- a/src/entity/routes.py
+++ b/src/entity/routes.py
@@ -1,5 +1,7 @@
 """Routes for dummy Entity model."""
 
+from __future__ import annotations
+
 import io
 from typing import Annotated
 

--- a/src/entity/schemas.py
+++ b/src/entity/schemas.py
@@ -1,5 +1,7 @@
 """Pydantic schemas for Entity dummy model."""
 
+from __future__ import annotations
+
 from pydantic.main import BaseModel
 
 

--- a/src/health/routes.py
+++ b/src/health/routes.py
@@ -1,5 +1,7 @@
 """Health endpoints."""
 
+from __future__ import annotations
+
 from fastapi import APIRouter
 
 

--- a/src/routes.py
+++ b/src/routes.py
@@ -1,5 +1,7 @@
 """Main app router combining all entities routers."""
 
+from __future__ import annotations
+
 from fastapi import APIRouter
 
 import src.entity.routes

--- a/src/shared/environment.py
+++ b/src/shared/environment.py
@@ -1,11 +1,17 @@
 """Utilities for working with environment variables."""
 
+from __future__ import annotations
+
 import os
-from typing import Final
+from typing import TYPE_CHECKING
 
 from dotenv import load_dotenv
 
 from src import PROJECT_ROOT
+
+
+if TYPE_CHECKING:
+    from typing import Final
 
 
 def load_environment() -> None:  # pragma: no cover

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,16 +3,21 @@
 from __future__ import annotations
 
 import asyncio
+from typing import TYPE_CHECKING
 
 import pytest
 from alembic.config import main as alembic
 from httpx import AsyncClient
-from sqlalchemy.ext.asyncio import async_scoped_session, async_sessionmaker, AsyncSession, create_async_engine
+from sqlalchemy.ext.asyncio import async_scoped_session, async_sessionmaker, create_async_engine
 
 from src.app import app
 from src.shared.database import get_session, POSTGRES_CONNECTION_URL
 from src.shared.minio import get_minio
 from tests.utils.database import set_autoincrement_counters
+
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
 
 
 def pytest_sessionstart(session: AsyncSession):

--- a/tests/test_entity/conftest.py
+++ b/tests/test_entity/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from src.entity.models import Entity

--- a/tests/test_entity/test_create_entity.py
+++ b/tests/test_entity/test_create_entity.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_entity/test_get_entity.py
+++ b/tests/test_entity/test_get_entity.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/test_health/test_get_health.py
+++ b/tests/test_health/test_get_health.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 

--- a/tests/utils/database.py
+++ b/tests/utils/database.py
@@ -1,5 +1,7 @@
 """Database utilities."""
 
+from __future__ import annotations
+
 from sqlalchemy import text
 
 from src.shared.database import async_engine, Base


### PR DESCRIPTION
Для использования новой системы аннотации типов модули должны содержать такой импорт:

```python
from __future__ import annotations
```

Наличие такого импорта позволяет использовать в аннотациях типы, которые определяются **после** аннотируемой функции (см. [PEP 563](https://peps.python.org/pep-0563/)), например:

```python
def foo(a: AClass) -> None:
    ... # do something with "a" object

class AClass:
    ... # class definintion

foo(AClass())
```

В этом примере кода `AClass` используется для аннотации параметра функции `foo`, до своего явного определения. Такой код будет давать ошибку, если использовать его без импорта `from __future__ import annotations`.

Также наличие этого импорта помогает линтерам. Например, в следущем коде `AClass` используется только для тайпхинта:

```python
from utils import AClass

def foo(a: AClass) -> None:
    ... # do something with "a" object
```

и если этот модуль будет содержать в себе импорт `annotations`, то линтер (рафф) сможет подсказать нам о том, что `AClass` используется только для тайпхинта и попросить вынести его в `if TYPE_CHECKING:` блок:

```python
from __future__ import annotations

from utils import AClass  # TCH002: Move third-party import `main.AClass` into a type-checking block

def foo(a: AClass) -> None:
    ... # do something with "a" object
```

Поскольку мы используем аннотации типов при разработке, мы бы хотели чтобы линтеры сразу предупреждали нас о таких type-checking импортах. Для этого мы можем проставить импорт `from __future__ import annotations` для всех существующих файлов, а также настроить рафф так, чтобы он требовал этот импорт в каждом `.py` файле.

Также рафф по умолчанию имеет параметр, который исключает из проверки на тайп чекинг все импорты из модуля `typing` (см. [доку](https://beta.ruff.rs/docs/settings/#exempt-modules)):

```toml
[tool.ruff.flake8-type-checking]
exempt-modules = ["typing"]
```

Это означает, что, например, в таком коде, рафф не будет требовать вынести `Final` в type-checking блок:

```python
from typing import Final

MAGIC_CONSTANT: Final = 42
```

Чтобы сохранить консистентность и выносить в type-checking **все** импорты, которые могут быть туда вынесены, то надо убрать модуль `typing` из этого параметра.

Также по умолчанию рафф не требует выносить импорт, который используется только для тайп чекинга, если есть другие импорты из того же модуля, которые используются в рантайме (см. [доку](https://beta.ruff.rs/docs/settings/#strict)), например:

```python
from collections import Counter, namedtuple

def foo(c: Counter) -> None:
    ...  # do something with "c"

nt = namedtuple(...)  # create some namedtuple
```

В этом коде `Counter` используется только для аннотации типа, но так как из модуля `collections` также импортируется `namedtuple`, который используется в рантайме, то рафф, не будет предупреждать нас о том, что `Counter` можно вынести в type-checking блок.

В рамках этой задачи необходимо:
- использовать правило раффа, которое требует наличие импорта `from __future__ import annotations`
- убрать дефолтные исключения раффа для модуля `typings`
- выставить опцию `strict = True`
- в каждом модуле пайтона и поправить type-checking импорты, о которых скажет рафф

PS. В рамках этой задачи мы решили не делать исключений для пакета с тестами `tests`. Хоть и на данный момент мы не проставляем типы в тестах, фикстурах и утилитах для тестов, но возможно в будущем будем. И в таком случае хотелось бы сразу знать об импортах, которые можно вынести в type-checking. Потому что когда мы решим типизировать тесты, мы можем просто забыть выставить этот параметр.