### PR TITLE
Запретить использование пустых строк в конфиге (#59)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -85,3 +85,9 @@ order-by-type = false
 
 # Add the specified import line to all files.
 required-imports = ["from __future__ import annotations"]
+
+
+[pep8-naming]
+
+# Indicate that the method should be treated as a class method (in addition to the builtin @classmethod).
+classmethod-decorators = ["pydantic.validator"]

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -98,5 +98,11 @@ tmp
 # utilities
 utils
 
+# validator
+validator
+
+# whitespaces
+whitespaces
+
 # project id, stands for "Wish List Sharing Service"
 wlss


### PR DESCRIPTION
На данный момент в качестве конфига мы используем класс, наследующийся от `pydantic.BaseSettings`. Этот класс позволяет нам указывать для каждой переменной окружения типы, согласно которым пайдэнтик будет проводит валидацию и десериализацию переменных окружения. Например:

```python
class Config(BaseSettings):
    APP_NAME: str
    MAGIC_NUMBER: int
```

Для данного конфига, `APP_NAME` и `MAGIC_NUMBER` это обязательные параметры, и если их не будет в переменных окружения, то пайдэнтик выдаст нам ошибку.

Но тут есть небольшой нюанс. Проблема в том, что если в переменных окружения для переменной, у которой тип указан как `str` не будет указано значение, например:
```bash
export APP_NAME=
```

То пайдэнтик не выдаст никакой ошибки, т.к. пустая строка, это абсолютно валидная строка `str("")`.

Но с точки зрения нашего приложения пустое значение переменной окружения это то же самое, что и отсуствие этого значения. Поэтому мы хотели бы так же получать ошибку в случае если значение переменной окружения это пустая строка.

Кроме того, строковый тип переменной так же может содержать leading и trailing whitespaces, например:

```bash
export MINIO_HOST="   localhost "
```

С точки зрения нашего приложения, эти пробелы не являются значащими (по крайней мере на данный момент я не могу придумать ни одного полезного кейса, в котором значение переменной окружения могло бы содержать эти пробелы). И тут у нас есть два пути решения этой проблемы: 1 - просто обрезать эти пробелы в рамках конфига и сохранять уже очищенное значение. 2 - выдывать ошибку, в случае если значение содержит эти пробелы.

Было принято решение использовать второй подход, т.к. на данный момент значения переменных для многих окружений закоммичены в репозиторий в `.env` файлах. Следовательно, если мы будем просто молча обрезать пробелы, то когда-нибудь разработчик может случайно закоммитить переменную с пробелами, и это нарушит консистетность - большинство переменных будут без пробелов и одна переменная с пробелами. Также наличие таких пробелов закоммиченых в репозиторий может вызвать вопросы, типа - "почему это сделано?", "возможно в этом есть какой-то смысл?", "надо ли мне делать так же?" и тд. Чтобы избежать всего этого можно воспользоваться вторым вариантом и сразу отдавать ошибку при попытке распарсить переменные окружения.

В рамках этой задачи необходимо настроить класс конфига так, чтобы он поднимал ошибку в случае если значение строковой переменной окружения (для типа `str`) является пустой строкой, а также если оно содержит пробелы в начале или в конце.

PS. Во время работы над это задачей пришлось переименовать класс конфига `Config` -> `_Config`, чтобы различать конфиг приложения и конфиг класс пайдэнтика:
```python
class Config:
    ... # some attributes here

    class Config:
         ... # pydantic special attributes here

    @validator
    def validate_types(
        cls: type[Config],  # <- здесь майпай не понимал, что мы имеем в виду внешний класс `Config`
        ...
    )
```

Одним из вариантов решения этой проблемы было бы переименовать `Config` -> `AppConfig`, но это решение не подошло, т.к. не хотелось нарушать консистетность имен:
```python

...

CONFIG: Final = AppConfg()  # тут как-то неочень красиво получается
                            # вроде и файл и переменная называются config,
                            # а класс назван по другому
```
Также мы предполагаем, в идеале, что этот конфиг всегда будет использоваться через переменную `CONFIG` и нигде кроме этого файла не будет инстанцироваться явно, типа `conf = Config()`. Соответственно этот класс можно сделать приватным, добавив к нему нижнее подчеркивание - `_Config`.