### PR TITLE
Добавить python-dotenv в pyproject.toml (#65)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1473,7 +1473,7 @@ six = ">=1.5"
 name = "python-dotenv"
 version = "1.0.0"
 description = "Read key-value pairs from a .env file and set them as environment variables"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
@@ -2157,4 +2157,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "9cb073e539e64eb6583ac1c770a2f7ffecf30ab6d2f0006765fa1f3d059944c1"
+content-hash = "70ff76dd848d627d2a88fcc798f26b266825f88e8243cde30d247d4feaa31dda"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ alembic = {extras = ["tz"], version = "1.10.4"}
 asyncpg = "0.27.0"  # asynchronous postgresql driver used by sqlalchemy
 fastapi = "0.95.0"
 minio = "7.1.14"
+python-dotenv = "1.0.0"
 sqlalchemy = {extras = ["asyncio"], version = "2.0.12"}
 
 


### PR DESCRIPTION
Во время добавления PostgreSQL (#29) мы использовали библиотеку [python-dotenv](https://pypi.org/project/python-dotenv/) для загрузки переменных окружения из файла. При этом мы забыли добавить её как явную зависимость в `pyproject.toml`.

Всё работало хорошо до этого дня, потому что эта библиотека являлась транзитивной зависимостью к `uvicorn`, который ставится нам в `dev` группу зависимостей т.к. мы указали там
```toml
fastapi = {extras = ["all"], version = "0.95.0"}
```

`uvirorn` как раз-таки входит в эти `extras = ["all"]`.

Т.к. до этого все наши окружения использовали `dev` группу зависимостей, то мы не знали об этой проблеме, но теперь, когда мы попытались настроить CD (#51), эта проблема стала видна, т.к. она ломает приложение на стенде после деплоя с такой ошибкой:
```bash
  File "/wlss-backend/src/shared/environment.py", line 8, in <module>
    from dotenv import load_dotenv
ModuleNotFoundError: No module named 'dotenv'
```

В рамках этой задачи необходимо добавить `python-dotenv` как основную зависимость в `pyproject.toml`.