### PR TITLE
Сделать dev группу зависимостей опциональной (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ source envs/local/dev/scripts/git/iam.sh
 
 2. Create virtual environment and install dependencies.
 ```bash
-poetry install
+poetry install --with dev
 ```
 
 3. Activate virtual environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,10 @@ python-dotenv = "1.0.0"
 sqlalchemy = {extras = ["asyncio"], version = "2.0.12"}
 
 
+[tool.poetry.group.dev]
+
+optional = true
+
 [tool.poetry.group.dev.dependencies]
 
 black = "23.3.0"


### PR DESCRIPTION
На данный момент, наша `dev` группа зависимостей не является опциональной. Это означает, что если при установке пакетов не указать никаких дополнительных параметров, т.е:

```bash
poetry install
```

то будут установлены зависимости из обоих групп - `main` и `dev`.

Это мешает нам в задаче добавления CD (#51). Т.к. в контейнер с приложением в рамках CD необходимо установить только зависимости из группы `main` и дополнительные зависимости из специальной группы `test` зависимостей для тестового стенда. Но там точно не должно быть зависимостей из `dev` группы.

Т.к. сейчас группа `dev` не является опциональной, то при запуске команды

```bash
poetry install --with test
```

будут установлены три группы зависимостей - `main`, `dev` и `test`. А должны быть только две - `main`, `test`.

В рамках этой задачи необходимо сделать группу `dev` зависимостей в файле `pyproject.toml` опциональной, а также перепроверить все места где используется `poetry install`.