### PR TITLE
Добавить pytest.mark.fixtures (#70)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,15 @@
 [pytest]
 
+addopts =
+    # Markers not registered in the `markers` section of the configuration file raise errors
+    --strict-markers
+
+markers =
+    fixtures: Used to populate 'f' fixture. Accepts dict as an argument
+                which maps fixture alias which will be used in this test
+                to its actual name. All fixtures described here in this mark
+                will be available as attributes of 'f' fixture.
+
 env =
     # will be default if $WLSS_ENV is not set
     D:WLSS_ENV=local/test

--- a/tests/test_entity/conftest.py
+++ b/tests/test_entity/conftest.py
@@ -6,7 +6,8 @@ from src.entity.models import Entity
 
 
 @pytest.fixture
-async def db_with_one_entity(db):
+async def db_with_one_entity(db_empty):
+    db = db_empty
     db.add(Entity(id=1, bucket="entity", key="entity-key"))
     await db.commit()
     return db

--- a/tests/test_entity/test_create_entity.py
+++ b/tests/test_entity/test_create_entity.py
@@ -9,22 +9,24 @@ from src.entity.models import Entity
 
 
 @pytest.mark.anyio
-async def test_create_entity_creates_objects_in_db_correctly(client, db):
-    result = await client.post("/entities", json={"bucket": "entity", "key": "entity-key"})
+@pytest.mark.fixtures({"client": "client", "db": "db_empty"})
+async def test_create_entity_creates_objects_in_db_correctly(f):
+    result = await f.client.post("/entities", json={"bucket": "entity", "key": "entity-key"})
 
     assert result.status_code == 200
-    entities = (await db.execute(select(Entity))).scalars().all()
+    entities = (await f.db.execute(select(Entity))).scalars().all()
     assert len(entities)
 
 
 @pytest.mark.anyio
-async def test_create_entity_stores_files_in_minio_correctly(client, db, minio, tmp_path):
-    tmp_path = Path(tmp_path)
+@pytest.mark.fixtures({"client": "client", "db": "db_empty", "minio": "minio_empty", "tmp_path": "tmp_path"})
+async def test_create_entity_stores_files_in_minio_correctly(f):
+    tmp_path = Path(f.tmp_path)
 
-    result = await client.post("/entities", json={"bucket": "entity", "key": "entity-key"})
+    result = await f.client.post("/entities", json={"bucket": "entity", "key": "entity-key"})
 
     assert result.status_code == 200
-    entity = (await db.execute(select(Entity))).scalar_one()
-    minio.fget_object(entity.bucket, entity.key, tmp_path / "file")
-    with (tmp_path / "file").open() as f:
-        assert f.read() == "some text"
+    entity = (await f.db.execute(select(Entity))).scalar_one()
+    f.minio.fget_object(entity.bucket, entity.key, tmp_path / "file")
+    with (tmp_path / "file").open() as f_:
+        assert f_.read() == "some text"

--- a/tests/test_entity/test_get_entity.py
+++ b/tests/test_entity/test_get_entity.py
@@ -4,8 +4,9 @@ import pytest
 
 
 @pytest.mark.anyio
-async def test_get_entity_returns_200_with_correct_body(client, db_with_one_entity):
-    result = await client.get("/entities/1")
+@pytest.mark.fixtures({"client": "client", "db": "db_with_one_entity"})
+async def test_get_entity_returns_200_with_correct_body(f):
+    result = await f.client.get("/entities/1")
 
     assert result.status_code == 200
     assert result.json() == {"id": 1, "bucket": "entity", "key": "entity-key"}

--- a/tests/test_health/test_get_health.py
+++ b/tests/test_health/test_get_health.py
@@ -4,8 +4,9 @@ import pytest
 
 
 @pytest.mark.anyio
-async def test_get_health_returns_correct_response(client):
-    result = await client.get("/health")
+@pytest.mark.fixtures({"client": "client"})
+async def test_get_health_returns_correct_response(f):
+    result = await f.client.get("/health")
 
     assert result.status_code == 200
     assert result.json() == {"status": "OK"}

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -37,6 +37,9 @@ fastapi
 # file get (used by `minio` library)
 fget
 
+# get fixture value (used by `pytest` library)
+getfixturevalue
+
 # health check
 healthcheck
 


### PR DESCRIPTION
Для удобства работы с фикстурами необходимо добавить фикстуру `f`, которая будет загружать фикстуры из марки `fixtures`. Эта фикстура должна работать так:
```python
@pytest.mark.fixtures({
    "alias1": "some_very_long_fixture_name_1",
    "alias2": "some_very_long_fixture_name_2",
    ...  # more fixtures if needed
})
def some_very_long_test_name(f):
    ...  # do something with `f.alias1` and `f.alias2`
```

Это подход позволит нам писать длинные имена фикстур, которые будут описывать предназначение каждой фикстуры, но при этом в рамках самого теста мы сможем обращаться к этим фикстурам с помощью коротких элиасов, которые мы определим в `@pytest.mark.fixtures`.

Кроме преимуществ у этого подхода есть также ряд недостатков:
- IDE не распознают фикстуры, определенные через нашу марку, поэтому быстрое перемещение к фикстуре в IDE будет недоступно
- фикстуру `f` нельзя использовать для загрузки фикстур в другие фикстуры, т.к. это вызывает ошибку рекурсии пайтеста

На данный момент преимущества перевешивают недостатки, поэтому было принято решение внедрить этот подход в проект. Но на будущее хотелось бы найти другой подход, который, в идеале, был бы лишен вышеперечисленных недостатков.