### PR TITLE
Настроить сваггер для  get_health эндпойнта (#74)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -20,6 +20,11 @@ src = ["src"]
     "TCH",  # Move import into a type-checking block
 ]
 
+# ignore checks that are raised only when using Pydantic models
+"src/**/schemas.py" = [
+    "TCH",  # Move import into a type-checking block
+]
+
 # files with fixtures
 "tests/**/conftest.py" = [
     "ARG001",  # Unused function argument: {name}

--- a/src/app.py
+++ b/src/app.py
@@ -7,6 +7,15 @@ from fastapi import FastAPI
 import src.routes
 
 
-app = FastAPI()
+app = FastAPI(
+    title="WLSS API",
+    description="Backend API for Wish List Sharing Service.",
+    openapi_tags=[
+        {
+            "name": "service",
+            "description": "Maintenace related functionality.",
+        },
+    ],
+)
 
 app.include_router(src.routes.router)

--- a/src/health/enums.py
+++ b/src/health/enums.py
@@ -1,0 +1,13 @@
+"""Enumerations for 'health' package."""
+
+from __future__ import annotations
+
+from src.shared import enum
+
+
+@enum.unique
+@enum.types(str)
+class HealthStatus(enum.Enum):
+    """Possible health statuses."""
+
+    OK = "OK"

--- a/src/health/routes.py
+++ b/src/health/routes.py
@@ -2,13 +2,34 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, status
+
+from src.health import enums, schemas
 
 
 router = APIRouter()
 
 
-@router.get("/health")
-async def get_health() -> dict[str, str]:
+@router.get(
+    "/health",
+    description="Check backend health.",
+    responses={
+        status.HTTP_200_OK: {
+            "description": "Backend application works fine.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "status": "OK",
+                    },
+                },
+            },
+        },
+    },
+    response_model=schemas.Health,
+    status_code=status.HTTP_200_OK,
+    summary="Check health.",
+    tags=["service"],
+)
+async def get_health() -> schemas.Health:
     """Classic health check function."""
-    return {"status": "OK"}
+    return schemas.Health(status=enums.HealthStatus.OK)

--- a/src/health/schemas.py
+++ b/src/health/schemas.py
@@ -1,0 +1,13 @@
+"""Pydantic schemas for 'health' package."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from src.health.enums import HealthStatus
+
+
+class Health(BaseModel):
+    """Service health status schema."""
+
+    status: HealthStatus

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -25,6 +25,9 @@ dotenv
 # enumeration (pylint spellcheck)
 enum
 
+# enumerations
+enums
+
 # environment
 env
 
@@ -54,6 +57,9 @@ minio
 
 # default username and password for MinIO
 minioadmin
+
+# OpenAPI Specification
+openapi
 
 # ORM - Object-Relational Mapping
 orm


### PR DESCRIPTION
В процессе добавления FastAPI (#21) мы создали простой healthcheck эндпойнт, который позволил бы нам проверить работоспособность приложения.

Так как сейчас мы приступаем к работе над функциональностью приложения, необходимо привести сваггер для этого эндпойнта в стандартный вид, чтобы он выглдяел единообразно со всеми остальными эндпойнтами, которые мы будем добавлять.