### PR TITLE
Поправить генерацию бейджей в README.md (#81)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
   mypy-badge:
     name: Mypy badge
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ (success() || failure()) && github.ref_name == 'develop' }}
     needs: [mypy]
     steps:
       - name: Create mypy badge
@@ -92,7 +92,7 @@ jobs:
   ruff-badge:
     name: Ruff badge
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ (success() || failure()) && github.ref_name == 'develop' }}
     needs: [ruff]
     steps:
       - name: Create ruff badge
@@ -132,7 +132,7 @@ jobs:
   flake8-badge:
     name: Flake8 badge
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ (success() || failure()) && github.ref_name == 'develop' }}
     needs: [flake8]
     steps:
       - name: Create flake8 badge
@@ -172,7 +172,7 @@ jobs:
   pylint-badge:
     name: Pylint badge
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ (success() || failure()) && github.ref_name == 'develop' }}
     needs: [pylint]
     steps:
       - name: Create pylint badge

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
   pytest-badge:
     name: Pytest badge
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ (success() || failure()) && github.ref_name == 'develop' }}
     needs: [pytest]
     steps:
       - name: Create pytest badge


### PR DESCRIPTION
При работе над задачей добавления бейджей для линтеров в README.md (#33), мы не учли, что состояние бейджей должно обновляться только при пуше в девелоп и не должно зависеть от пушей фича-веток. И как следствие, сейчас наши бейджи обновляются даже при пуше в фича-ветку. Т.е. если например мы работаем над какой-нибудь фичей и пушим в фича-ветку какой-нибудь in progress коммит, в котором не работает какой-либо линтер, то соответствующий бейдж в README.md обновляет свой статус на failed, хотя при этом в девелопе все линтеры отрабатывают со статусом success.

В рамках этой задачи необходимо поправить генерацию бейджей так, чтобы они генерировались только при пуше основной ветки - девелопа.