### PR TITLE
Добавить авторелоад в команду запуска приложения в README.md (#83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ WLSS_ENV=local/dev alembic upgrade head
 
 4. Run FastAPI.
 ```bash
-WLSS_ENV=local/dev uvicorn src.app:app
+WLSS_ENV=local/dev uvicorn src.app:app --reload
 ```
 
 5. Check health status.


### PR DESCRIPTION
Т.к. опция авторелоада при изменении кода очень полезна для разработки, то хотелось бы добавить её в команду описанную в README.md в разделе "Run app", чтобы не дописывать её каждый раз руками.

В рамках этой задачи необходимо добавить опцию `--reload` в команду запуска приложения в файле README.md