### PR TITLE
Добавить сваггер для эндпойнтов авторизации (#77)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -95,4 +95,4 @@ required-imports = ["from __future__ import annotations"]
 [pep8-naming]
 
 # Indicate that the method should be treated as a class method (in addition to the builtin @classmethod).
-classmethod-decorators = ["pydantic.validator"]
+classmethod-decorators = ["pydantic.root_validator", "pydantic.validator"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1170,6 +1170,18 @@ files = [
 ]
 
 [[package]]
+name = "overrides"
+version = "7.3.1"
+description = "A decorator to automatically detect mismatch when overriding a method."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "overrides-7.3.1-py3-none-any.whl", hash = "sha256:6187d8710a935d09b0bcef8238301d6ee2569d2ac1ae0ec39a8c7924e27f58ca"},
+    {file = "overrides-7.3.1.tar.gz", hash = "sha256:8b97c6c1e1681b78cbc9424b138d880f0803c2254c5ebaabdde57bb6c62093f2"},
+]
+
+[[package]]
 name = "packaging"
 version = "23.1"
 description = "Core utilities for Python packages"
@@ -2178,4 +2190,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "a1a1bf49fc205786b565dcabd7801fadf6bcc745e61920f9cb9f38cf4031a478"
+content-hash = "b879d9c7ed4bd92f0eb8c501200870642174df6a8986ec014887e588999935d0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ alembic = {extras = ["tz"], version = "1.10.4"}
 asyncpg = "0.27.0"  # asynchronous postgresql driver used by sqlalchemy
 fastapi = {extras = ["all"], version = "0.95.0" }  # we need "all" at least for uvicorn
 minio = "7.1.14"
+overrides = "7.3.1"
 python-dotenv = "1.0.0"
 sqlalchemy = {extras = ["asyncio"], version = "2.0.12"}
 

--- a/src/account/__init__.py
+++ b/src/account/__init__.py
@@ -1,0 +1,1 @@
+"""Package for account related functionality."""

--- a/src/account/fields.py
+++ b/src/account/fields.py
@@ -1,0 +1,23 @@
+"""Field definitions for Pydantic models."""
+
+from __future__ import annotations
+
+from src.shared.fields import StrField
+
+
+class Email(StrField):
+    """Email value field."""
+
+    FIELD_NAME = "Email"
+    LENGTH_MAX = 200
+    LENGTH_MIN = 5
+    REGEXP = r".+@.+\..+"
+
+
+class Login(StrField):
+    """Login value field."""
+
+    FIELD_NAME = "Login"
+    LENGTH_MAX = 50
+    LENGTH_MIN = 1
+    REGEXP = r"[A-Za-z0-9\-_]*"

--- a/src/account/schemas.py
+++ b/src/account/schemas.py
@@ -1,0 +1,20 @@
+"""Schemas for account related functionality."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import PositiveInt
+
+from src.account.fields import Email, Login
+from src.shared.schemas import Schema
+
+
+class Account(Schema):
+    """Existing account model."""
+
+    id: PositiveInt  # noqa: A003
+
+    created_at: datetime
+    email: Email
+    login: Login

--- a/src/app.py
+++ b/src/app.py
@@ -12,6 +12,10 @@ app = FastAPI(
     description="Backend API for Wish List Sharing Service.",
     openapi_tags=[
         {
+            "name": "auth",
+            "description": "Auth-related functionality for Signing Up/In/Out.",
+        },
+        {
             "name": "service",
             "description": "Maintenace related functionality.",
         },

--- a/src/auth/__init__.py
+++ b/src/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Package for Sign Up/In/Out related functionality."""

--- a/src/auth/exceptions.py
+++ b/src/auth/exceptions.py
@@ -1,0 +1,12 @@
+"""Exceptions for auth related functionality."""
+
+from __future__ import annotations
+
+from src.shared.exceptions import HTTPException
+
+
+class NotAuthenticatedException(HTTPException):
+    """Exception for 401 UNAUTHORIZED error."""
+
+    description = "Request initiator is not authenticated."
+    details = "Your credentials or tokens are invalid or missing."

--- a/src/auth/fields.py
+++ b/src/auth/fields.py
@@ -1,0 +1,13 @@
+"""Field definitions for Pydantic models."""
+
+from __future__ import annotations
+
+from src.shared.fields import SecretStrField
+
+
+class Password(SecretStrField):
+    """Password value field."""
+
+    FIELD_NAME = "Password"
+    LENGTH_MIN = 8
+    LENGTH_MAX = 500

--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -1,0 +1,228 @@
+"""Auth related endpoints."""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Body, Depends, Path, status
+from fastapi.security import HTTPAuthorizationCredentials
+from pydantic import PositiveInt
+
+from src.auth import schemas, swagger
+from src.auth.security import get_token
+from src.shared import swagger as shared_swagger
+
+
+router = APIRouter(tags=["auth"])
+
+
+@router.post(
+    "/accounts",
+    description="Sign Up - create a new account with profile.",
+    responses={
+        status.HTTP_201_CREATED: {
+            "description": "New account and profile are created.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "account": {
+                            "id": 42,
+                            "email": "john.doe@mail.com",
+                            "login": "john_doe",
+                            "created_at": "2023-06-17T11:47:02.823Z",
+                        },
+                        "profile": {
+                            "account_id": 42,
+                            "avatar": None,
+                            "description": None,
+                            "name": "John Doe",
+                        },
+                    },
+                },
+            },
+        },
+    },
+    response_model=schemas.AccountWithProfile,
+    status_code=status.HTTP_201_CREATED,
+    summary="Sign Up - create a new account.",
+)
+def create_account(
+    new_account: Annotated[  # noqa: ARG001
+        schemas.NewAccountWithProfile,
+        Body(
+            example={
+                "account": {
+                    "email": "john.doe@mail.com",
+                    "login": "john_doe",
+                    "password": "qwerty123",
+                },
+                "profile": {
+                    "name": "John Doe",
+                },
+            },
+        ),
+    ],
+) -> None:
+    """Create a new account with profile."""
+
+
+@router.post(
+    "/accounts/{account_id}/tokens",
+    description="Sign In - exchange account credentials to Access and Refresh tokens.",
+    responses={
+        status.HTTP_201_CREATED: {
+            "description": "Credentials are valid, fresh tokens for new device are created.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "device_id": "b9dd3a32-aee8-4a6b-a519-def9ca30c9ec",
+                        "access_token": (
+                            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6N"
+                            "DJ9.YKVpm2zdxup0_ts81Ft4USo-AUMKXBCTfgXtNFbRLlg"
+                        ),
+                        "refresh_token": (
+                            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo0MiwiZGV2aWNlX2lkIj"
+                            "oxOCwiZXhwIjoxNjg3MjU2MTMxfQ.GgXVGPV1aE2GjyRWN_IrHaEkZwY_x0gs25lJKtgspX0"
+                        ),
+                    },
+                },
+            },
+        },
+        status.HTTP_401_UNAUTHORIZED: swagger.responses[status.HTTP_401_UNAUTHORIZED],
+        status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
+        status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
+    },
+    response_model=schemas.Tokens,
+    status_code=status.HTTP_201_CREATED,
+    summary="Sign In - create tokens for new device.",
+)
+def create_tokens(
+    account_id: Annotated[PositiveInt, Path(example=42)],  # noqa: ARG001
+    credentials: Annotated[  # noqa: ARG001
+        schemas.Credentials,
+        Body(
+            examples={
+                "With login": {
+                    "description": "Sign In via login and password.",
+                    "value": {
+                        "login": "john_doe",
+                        "password": "qwerty123",
+                    },
+                },
+                "With email": {
+                    "description": "Sign In via email and password.",
+                    "value": {
+                        "email": "john.doe@mail.com",
+                        "password": "qwerty123",
+                    },
+                },
+                "Invalid - no login, no email": {
+                    "description": "Invalid request - email or login is required.",
+                    "value": {
+                        "password": "qwerty123",
+                    },
+                },
+                "Invalid - both login and email": {
+                    "description": "Invalid request - you can not use login and email together.",
+                    "value": {
+                        "login": "john_doe",
+                        "email": "john.doe@mail.com",
+                        "password": "qwerty123",
+                    },
+                },
+            },
+        ),
+    ],
+) -> None:
+    """Create new tokens for the account."""
+
+
+@router.put(
+    "/accounts/{account_id}/tokens/{device_id}/refresh",
+    responses={
+        status.HTTP_200_OK: {
+            "description": "Exchange refresh token to the new Access and Refresh tokens.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "device_id": "b9dd3a32-aee8-4a6b-a519-def9ca30c9ec",
+                        "access_token": (
+                            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6N"
+                            "DJ9.YKVpm2zdxup0_ts81Ft4USo-AUMKXBCTfgXtNFbRLlg"
+                        ),
+                        "refresh_token": (
+                            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo0MiwiZGV2aWNlX2lkIj"
+                            "oxOCwiZXhwIjoxNjg3MjU2MTMxfQ.GgXVGPV1aE2GjyRWN_IrHaEkZwY_x0gs25lJKtgspX0"
+                        ),
+                    },
+                },
+            },
+        },
+        status.HTTP_401_UNAUTHORIZED: swagger.responses[status.HTTP_401_UNAUTHORIZED],
+        status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
+        status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
+    },
+    response_model=schemas.Tokens,
+    status_code=status.HTTP_200_OK,
+    summary="Refresh tokens for one device.",
+)
+def refresh_tokens(
+    account_id: Annotated[PositiveInt, Path(example=42)],  # noqa: ARG001
+    device_id: Annotated[UUID, Path(example="b9dd3a32-aee8-4a6b-a519-def9ca30c9ec")],  # noqa: ARG001
+    tokens: Annotated[  # noqa: ARG001
+        schemas.RefreshToken,
+        Body(
+            example={
+                "refresh_token": (
+                    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo0MiwiZGV2aWNlX2lkIj"
+                    "oxOCwiZXhwIjoxNjg3MjU2MTMxfQ.GgXVGPV1aE2GjyRWN_IrHaEkZwY_x0gs25lJKtgspX0"
+                ),
+            },
+        ),
+    ],
+) -> None:
+    """Refresh tokens."""
+
+
+@router.delete(
+    "/accounts/{account_id}/tokens/{device_id}",
+    responses={
+        status.HTTP_204_NO_CONTENT: {
+            "description": "All tokens for particular device are removed. User has been signed out from this device.",
+        },
+        status.HTTP_401_UNAUTHORIZED: swagger.responses[status.HTTP_401_UNAUTHORIZED],
+        status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
+        status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
+    },
+    response_model=None,
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Sign Out from one device.",
+)
+def remove_device_tokens(
+    account_id: Annotated[PositiveInt, Path(example=42)],  # noqa: ARG001
+    device_id: Annotated[UUID, Path(example="b9dd3a32-aee8-4a6b-a519-def9ca30c9ec")],  # noqa: ARG001
+    access_token: Annotated[HTTPAuthorizationCredentials, Depends(get_token)],  # noqa: ARG001
+) -> None:
+    """Remove tokens for particular device."""
+
+
+@router.delete(
+    "/accounts/{account_id}/tokens",
+    responses={
+        status.HTTP_204_NO_CONTENT: {
+            "description": "All account tokens are removed. User has been signed out from all devices.",
+        },
+        status.HTTP_401_UNAUTHORIZED: swagger.responses[status.HTTP_401_UNAUTHORIZED],
+        status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
+        status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
+    },
+    response_model=None,
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Sign Out from all devices.",
+)
+def remove_all_tokens(
+    account_id: Annotated[PositiveInt, Path(example=42)],  # noqa: ARG001
+    access_token: Annotated[HTTPAuthorizationCredentials, Depends(get_token)],  # noqa: ARG001
+) -> None:
+    """Remove tokens for all devices related to account."""

--- a/src/auth/schemas.py
+++ b/src/auth/schemas.py
@@ -1,0 +1,89 @@
+"""Auth related schemas."""
+
+from __future__ import annotations
+
+from typing import Any, TypeVar
+from uuid import UUID
+
+from pydantic import root_validator
+
+from src.account.fields import Email, Login
+from src.account.schemas import Account
+from src.auth.fields import Password
+from src.profile.fields import Name
+from src.profile.schemas import Profile
+from src.shared.schemas import HTTPError, Schema
+
+
+DictT = TypeVar("DictT", bound=dict[str, Any])
+
+
+class NotAuthenticatedResponse(HTTPError):  # noqa: N818
+    """Schema for 401 UNAUTHORIZED response."""
+
+
+class _NewAccount(Schema):
+    """Account data which is going to be created during sign up process."""
+
+    email: Email
+    login: Login
+    password: Password
+
+
+class _NewProfile(Schema):
+    """Profile data for an account which is going to be created during sign up process."""
+
+    name: Name
+
+
+class NewAccountWithProfile(Schema):
+    """Account and corresponding profile data which are going to be created during sign up process."""
+
+    account: _NewAccount
+    profile: _NewProfile
+
+
+class AccountWithProfile(Schema):
+    """Account and corresponding profile which have been created during sign up process."""
+
+    account: Account
+    profile: Profile
+
+
+class Credentials(Schema):
+    """Account credentials for sign in process. Can be a pair of password and email or password and login."""
+
+    email: Email | None
+    login: Login | None
+    password: Password
+
+    @classmethod  # to silent mypy error, because mypy doesn't recognize root_validator as a classmethod
+    @root_validator(pre=True)
+    def _require_login_or_email(cls: type[Credentials], values: DictT) -> DictT:  # pragma: no cover
+        if not (values["login"] or values["email"]):
+            msg = "Either 'login' or 'email' is required."
+            raise ValueError(msg)
+        return values
+
+    @classmethod  # to silent mypy error, because mypy doesn't recognize root_validator as a classmethod
+    @root_validator(pre=True)
+    def _forbid_login_and_email_together(cls: type[Credentials], values: DictT) -> DictT:  # pragma: no cover
+        if values["login"] and values["email"]:
+            msg = "You cannot use 'login' and 'email' together. Choose one of them."
+            raise ValueError(msg)
+        return values
+
+
+class Tokens(Schema):
+    """Account tokens attached to a particular device."""
+
+    device_id: UUID
+    access_token: str
+    refresh_token: str
+
+
+class RefreshToken(Schema):
+    """Refresh token for a particular device."""
+
+    device_id: UUID
+    refresh_token: str

--- a/src/auth/security.py
+++ b/src/auth/security.py
@@ -1,0 +1,11 @@
+"""Security stuff for auth related functionality."""
+
+from __future__ import annotations
+
+from fastapi.security import HTTPBearer
+
+
+get_token = HTTPBearer(
+    scheme_name="Access Token",
+    description="Short-living token needed to authenticate the request.",
+)

--- a/src/auth/swagger.py
+++ b/src/auth/swagger.py
@@ -1,0 +1,23 @@
+"""Swagger definitions related stuff."""
+
+from __future__ import annotations
+
+from fastapi import status
+
+from src.auth import exceptions, schemas
+
+
+responses = {
+    status.HTTP_401_UNAUTHORIZED: {
+        "description": "Provided tokens or credentials are invalid or missing.",
+        "model": schemas.NotAuthenticatedResponse,
+        "content": {
+            "application/json": {
+                "example": {
+                    "description": exceptions.NotAuthenticatedException.description,
+                    "details": exceptions.NotAuthenticatedException.details,
+                },
+            },
+        },
+    },
+}

--- a/src/profile/__init__.py
+++ b/src/profile/__init__.py
@@ -1,0 +1,1 @@
+"""Package for profile related functionality."""

--- a/src/profile/fields.py
+++ b/src/profile/fields.py
@@ -1,0 +1,28 @@
+"""Field definitions for Pydantic models."""
+
+from __future__ import annotations
+
+from src.shared.fields import StrField
+
+
+class Avatar(str):
+    """Avatar value field."""
+
+
+class Description(StrField):
+    """Description value field."""
+
+    FIELD_NAME = "Profile Description"
+    LENGTH_MAX = 1000
+    LENGTH_MIN = 1
+    REGEXP = r".{1,1000}"
+
+
+class Name(StrField):
+    """Name value field."""
+
+    FIELD_NAME = "Profile Name"
+    LENGTH_MAX = 100
+    LENGTH_MIN = 1
+
+    REGEXP = r"[A-Za-zА-яЁё'-.() ]*"  # noqa: RUF001

--- a/src/profile/schemas.py
+++ b/src/profile/schemas.py
@@ -1,0 +1,18 @@
+"""Schemas for profile related functionality."""
+
+from __future__ import annotations
+
+from pydantic import PositiveInt
+
+from src.profile.fields import Avatar, Description, Name
+from src.shared.schemas import Schema
+
+
+class Profile(Schema):
+    """Account profile."""
+
+    account_id: PositiveInt
+
+    avatar: Avatar | None
+    description: Description | None
+    name: Name

--- a/src/routes.py
+++ b/src/routes.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+import src.auth.routes
 import src.health.routes
 
 
 router = APIRouter()
 
+router.include_router(src.auth.routes.router)
 router.include_router(src.health.routes.router)

--- a/src/shared/exceptions.py
+++ b/src/shared/exceptions.py
@@ -1,0 +1,49 @@
+"""Exceptions shared by different application components."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from typing import Any, Self
+
+
+class HTTPException(Exception):  # noqa: N818
+    """Base class for all app exceptions."""
+
+    description = "Unknown error occured."
+    details = "Please contact backend maintenance team."
+
+    def __init__(self: Self, details: str = "") -> None:  # pragma: no cover
+        """Initialize object."""
+        self.details = details
+        super().__init__()
+
+
+class NotFoundException(HTTPException):
+    """Exception for 404 NOT FOUND error."""
+
+    resource: str
+
+    description = "Requested resource not found."
+    details = "Requested resource doesn't exist or has been deleted."
+
+    def __init__(self: Self, resource: str, *args: Any, **kwargs: Any) -> None:  # pragma: no cover
+        """Initialize object."""
+        self.resource = resource
+        super().__init__(*args, **kwargs)
+
+
+class NotAllowedException(HTTPException):
+    """Exception for 403 FORBIDDEN error."""
+
+    action: str
+
+    description = "Requested action not allowed."
+    details = "Provided tokens or credentials don't grant you enough access rights."
+
+    def __init__(self: Self, action: str, *args: Any, **kwargs: Any) -> None:  # pragma: no cover
+        """Initialize object."""
+        self.action = action
+        super().__init__(*args, **kwargs)

--- a/src/shared/fields.py
+++ b/src/shared/fields.py
@@ -1,0 +1,154 @@
+"""Field definitions shared by different application components."""
+
+from __future__ import annotations
+
+import re
+from typing import final, TYPE_CHECKING
+
+from overrides import override
+from pydantic import SecretStr
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
+    from typing import Any
+
+    from pydantic import PositiveInt
+
+
+class StrField(str):
+    """String field for Pydantic models."""
+
+    FIELD_NAME: str = "Value"
+    LENGTH_MAX: PositiveInt
+    LENGTH_MIN: PositiveInt
+    REGEXP: str | None = None
+
+    @classmethod
+    def __get_validators__(
+        cls: type[StrField],
+    ) -> Generator[Callable[[str], str | StrField], None, None]:  # pragma: no cover
+        """Pydantic's special method. Can be overridden in sub-classes."""
+        yield cls._validate_length
+        yield cls._validate_regexp
+        yield cls.cast_type
+
+    def __init_subclass__(cls: type[StrField]) -> None:  # pragma: no cover
+        """Validate subclass for the presence of required class attributes and other constraints."""
+        if not hasattr(cls, "LENGTH_MIN") or not hasattr(cls, "LENGTH_MAX"):
+            msg = "LENGTH_MIN or LENGTH_MAX should be defined in a subclass."
+            raise RuntimeError(msg)
+        if cls.LENGTH_MIN > cls.LENGTH_MAX:
+            msg = "LENGTH_MIN cannot be greater than LENGTH_MAX"
+            raise RuntimeError(msg)
+
+    @classmethod
+    @final
+    def _validate_length(cls: type[StrField], value: str) -> str:  # pragma: no cover
+        if len(value) < cls.LENGTH_MIN:
+            msg = f"{cls.FIELD_NAME} length should not be less than {cls.LENGTH_MIN}."
+            raise ValueError(msg)
+        if len(value) > cls.LENGTH_MAX:
+            msg = f"{cls.FIELD_NAME} length should not be greater than {cls.LENGTH_MAX}."
+            raise ValueError(msg)
+        return value
+
+    @classmethod
+    @final
+    def _validate_regexp(cls: type[StrField], value: str) -> str:  # pragma: no cover
+        if cls.REGEXP is not None and not re.fullmatch(cls.REGEXP, value):
+            msg = rf"{cls.FIELD_NAME} should match regular expression: {cls.REGEXP}"
+            raise ValueError(msg)
+        return value
+
+    @classmethod
+    def cast_type(cls: type[StrField], value: str) -> StrField:  # pragma: no cover
+        """Cast value type to the corresponding class after all validations are completed.
+
+        Can be overridden in sub-classes.
+
+        :param value: string value after all validations
+        :return: instance of the class which string value have been cast to
+        """
+        return cls(value)
+
+    @classmethod
+    def __modify_schema__(cls: type[StrField], field_schema: dict[str, Any]) -> None:  # pragma: no cover
+        """Pydantic's special method to modify field representation in OpenAPI schema."""
+        field_schema.update({
+            "length_max": cls.LENGTH_MAX,
+            "length_min": cls.LENGTH_MIN,
+            "regexp": cls.REGEXP,
+        })
+
+
+class SecretStrField(SecretStr):
+    """String field which value should be secret and not exposed in logging accidentally.
+
+    We duplicated all StrField functionality here instead of using multiple inheritance in order to avoid
+    method resolution order issues which may come with multiple inheritance.
+    """
+
+    FIELD_NAME: str = "Value"
+    LENGTH_MAX: PositiveInt
+    LENGTH_MIN: PositiveInt
+    REGEXP: str | None = None
+
+    def __init_subclass__(cls: type[SecretStrField]) -> None:  # pragma: no cover
+        """Validate subclass for the presence of required class attributes and other constraints."""
+        if not hasattr(cls, "LENGTH_MIN") or not hasattr(cls, "LENGTH_MAX"):
+            msg = "LENGTH_MIN or LENGTH_MAX should be defined in a subclass."
+            raise RuntimeError(msg)
+        if cls.LENGTH_MIN > cls.LENGTH_MAX:
+            msg = "LENGTH_MIN cannot be greater than LENGTH_MAX"
+            raise RuntimeError(msg)
+
+    @classmethod
+    @override
+    def __get_validators__(
+        cls: type[SecretStrField],
+    ) -> Generator[Callable[[str], str | SecretStrField], None, None]:  # pragma: no cover
+        """Pydantic's special method. Can be overridden in sub-classes."""
+        yield cls._validate_length
+        yield cls._validate_regexp
+        yield cls.cast_type
+
+    @classmethod
+    @final
+    def _validate_length(cls: type[SecretStrField], value: str) -> str:  # pragma: no cover
+        if len(value) < cls.LENGTH_MIN:
+            msg = f"{cls.FIELD_NAME} length should not be less than {cls.LENGTH_MIN}."
+            raise ValueError(msg)
+        if len(value) > cls.LENGTH_MAX:
+            msg = f"{cls.FIELD_NAME} length should not be greater than {cls.LENGTH_MAX}."
+            raise ValueError(msg)
+        return value
+
+    @classmethod
+    @final
+    def _validate_regexp(cls: type[SecretStrField], value: str) -> str:  # pragma: no cover
+        if cls.REGEXP is not None and not re.fullmatch(cls.REGEXP, value):
+            msg = rf"{cls.FIELD_NAME} should match regular expression: {cls.REGEXP}"
+            raise ValueError(msg)
+        return value
+
+    @classmethod
+    def cast_type(cls: type[SecretStrField], value: str) -> SecretStrField:  # pragma: no cover
+        """Cast value type to the corresponding class after all validations are completed.
+
+        Can be overridden in sub-classes.
+
+        :param value: string value after all validations
+        :return: instance of the class which string value have been cast to
+        """
+        return cls(value)
+
+    @classmethod
+    @override
+    def __modify_schema__(cls: type[SecretStrField], field_schema: dict[str, Any]) -> None:  # pragma: no cover
+        """Pydantic's special method to modify field representation in OpenAPI schema."""
+        field_schema.update({
+            "length_max": cls.LENGTH_MAX,
+            "length_min": cls.LENGTH_MIN,
+            "regexp": cls.REGEXP,
+        })

--- a/src/shared/schemas.py
+++ b/src/shared/schemas.py
@@ -1,0 +1,35 @@
+"""Pydantic models shared by different application components."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class Schema(BaseModel):
+    """Customized 'BaseModel' class from pydantic."""
+
+    class Config:
+        """Pydantic's special class to configure pydantic models."""
+
+        json_encoders = {datetime: lambda v: v.strftime("%Y-%m-%dT%H:%M:%S.%fZ")}  # pragma: no cover
+
+
+class HTTPError(Schema):
+    """Base schema for errors."""
+
+    description: str
+    details: str
+
+
+class NotFoundResponse(HTTPError):  # noqa: N818
+    """Schema for 404 NOT FOUND error."""
+
+    resource: str
+
+
+class NotAllowedResponse(HTTPError):  # noqa: N818
+    """Schema for 403 FORBIDDEN error."""
+
+    action: str

--- a/src/shared/swagger.py
+++ b/src/shared/swagger.py
@@ -1,0 +1,37 @@
+"""Swagger related stuff shared by different application components."""
+
+from __future__ import annotations
+
+from fastapi import status
+
+from src.shared import exceptions, schemas
+
+
+responses = {  # pylint: disable=consider-using-namedtuple-or-dataclass
+    status.HTTP_403_FORBIDDEN: {
+        "description": "Provided tokens or credentials don't grant you enough access rights.",
+        "model": schemas.NotAllowedResponse,
+        "content": {
+            "application/json": {
+                "example": {
+                    "action": "<requested action description will be here>",
+                    "description": exceptions.NotAllowedException.description,
+                    "details": exceptions.NotAllowedException.details,
+                },
+            },
+        },
+    },
+    status.HTTP_404_NOT_FOUND: {
+        "description": "Requested resource doesn't exist.",
+        "model": schemas.NotFoundResponse,
+        "content": {
+            "application/json": {
+                "example": {
+                    "resource": "<requested resource description will be here>",
+                    "description": exceptions.NotFoundException.description,
+                    "details": exceptions.NotFoundException.details,
+                },
+            },
+        },
+    },
+}

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -13,8 +13,14 @@ async
 # Python standart library for asynchronous code (pylint spellcheck)
 asyncio
 
+# Auth - short for both Authorization and Authentication (pylint spellcheck)
+auth
+
 # auto increment
 autoincrement
+
+# class method (pylint spellcheck)
+classmethod
 
 # configuration component
 config
@@ -40,6 +46,9 @@ fastapi
 # file get (used by `minio` library)
 fget
 
+# full match (used by `re` library)
+fullmatch
+
 # get fixture value (used by `pytest` library)
 getfixturevalue
 
@@ -57,6 +66,9 @@ minio
 
 # default username and password for MinIO
 minioadmin
+
+# MyPy - static type checker for python (pylint spellcheck)
+mypy
 
 # OpenAPI Specification
 openapi
@@ -109,6 +121,9 @@ utils
 
 # validator
 validator
+
+# validators
+validators
 
 # whitespaces
 whitespaces


### PR DESCRIPTION
Перед тем как приступить к реализации эндпойнтов авторизации, необходимо продумать их архитектуру и создать контракты.

Было принято решение реализовать упрощённую реализацию OAuth своими силами, чтобы лучше разобраться в работе протокола. Описание концепций, которые мы планируем реализовать находится на отдельной вики [странице](https://github.com/week-password/wisher/wiki/%D0%90%D0%BD%D0%B0%D0%BB%D0%B8%D1%82%D0%B8%D0%BA%D0%B0.-%D0%90%D0%B2%D1%82%D0%BE%D1%80%D0%B8%D0%B7%D0%B0%D1%86%D0%B8%D1%8F) (если эта ссылка, по какой-то причине отвалилась, то смотри комментарии к тикету #77 на гитхабе).

В рамках этой задачи необходимо продумать архитектуру эндпойнтов авторизации и добавить определения сваггера.