### PR TITLE
Перенести тэг service из роута в роутер (#86)

### DIFF
--- a/src/health/routes.py
+++ b/src/health/routes.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, status
 from src.health import enums, schemas
 
 
-router = APIRouter()
+router = APIRouter(tags=["service"])
 
 
 @router.get(
@@ -28,7 +28,6 @@ router = APIRouter()
     response_model=schemas.Health,
     status_code=status.HTTP_200_OK,
     summary="Check health.",
-    tags=["service"],
 )
 async def get_health() -> schemas.Health:
     """Classic health check function."""


### PR DESCRIPTION
Во процессе настройки сваггера для get_health эндпойнта (#74) мы поставили тэг "service" в определение роута, но т.к. в будущем у нас могут добавляться другие "сервис-роуты", то для каждого из них придётся проставлять тэг отдельно.

В связи с этим было принято решение перенести тэг из определения роута в роутер, чтобы все роуты закрепленные в этом роутере по умолчанию имели тэг "service".

Также может возникнуть ситуация по которой роутер может иметь больше одного тэга - например, если роут может выполнять функциональность, которая может быть полезна "с нескольких точек зрения".  Например, роут регистрации с одной стороны является роутом для авторизации, т.е. у него должен быть тэг "auth", но также этот роут представляет из себя создание новой сущности юзера в системе, поэтому у него может быть также тэг "user". И для таких случаев все дополнительные тэги, которые могут обозначать другой контекст применения определенного роута, мы будем указывать в определении самого роута. Таким образом роут регистрации по умолчанию будет закреплен в роутере с тэгом "auth", но так как он может использоваться ещё и в контексте работы с юзером, то для самого роута можно будет указать дополнительный тэг "user".

В рамках этой задачи необходимо перенести тэг "service" из определения роута в определение роутера.