### PR TITLE
Добавить описание профиля в эндпойнт регистрации (#90)

### DIFF
--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -35,7 +35,7 @@ router = APIRouter(tags=["auth"])
                         "profile": {
                             "account_id": 42,
                             "avatar": None,
-                            "description": None,
+                            "description": "Who da heck is John Doe?",
                             "name": "John Doe",
                         },
                     },
@@ -59,6 +59,7 @@ def create_account(
                 },
                 "profile": {
                     "name": "John Doe",
+                    "description": "Who da heck is John Doe?",
                 },
             },
         ),

--- a/src/auth/schemas.py
+++ b/src/auth/schemas.py
@@ -10,7 +10,7 @@ from pydantic import root_validator
 from src.account.fields import Email, Login
 from src.account.schemas import Account
 from src.auth.fields import Password
-from src.profile.fields import Name
+from src.profile.fields import Description, Name
 from src.profile.schemas import Profile
 from src.shared.schemas import HTTPError, Schema
 
@@ -34,6 +34,7 @@ class _NewProfile(Schema):
     """Profile data for an account which is going to be created during sign up process."""
 
     name: Name
+    description: Description | None
 
 
 class NewAccountWithProfile(Schema):


### PR DESCRIPTION
Во время работы над добавлением сваггера для эндпойнтов авторизации (#77), мы забыли добавить поле description, которое пользователь может заполнить на экране регистрации.

В рамках этой задачи необходимо добавить поле description в сваггер эндпойнта регистрации, а также прописать его в схему `_NewProfile`, которая используется для описания входных данных профиля при регистрации.