### PR TITLE
Добавить сваггер для эндпойнтов аккаунта

### DIFF
--- a/src/account/routes.py
+++ b/src/account/routes.py
@@ -1,0 +1,87 @@
+"""Account related endpoints."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Body, Depends, Path, status
+from fastapi.security import HTTPAuthorizationCredentials
+
+from src.account import schemas
+from src.account.fields import Login
+from src.auth import swagger as auth_swagger
+from src.auth.security import get_token
+from src.shared import swagger as shared_swagger
+
+
+router = APIRouter(tags=["account"])
+
+
+@router.get(
+    "/accounts/logins/{account_login}/id",
+    description="Get Account Id by login. Account Id is available for every logged in user.",
+    responses={
+        status.HTTP_200_OK: {
+            "description": "Account Id returned",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "id": 42,
+                    },
+                },
+            },
+        },
+        status.HTTP_401_UNAUTHORIZED: auth_swagger.responses[status.HTTP_401_UNAUTHORIZED],
+        status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
+    },
+    response_model=schemas.AccountId,
+    status_code=status.HTTP_200_OK,
+    summary="Get Account Id.",
+)
+async def get_account_id(
+    account_login: Annotated[Login, Path(example="john_doe")],  # noqa: ARG001
+    access_token: Annotated[HTTPAuthorizationCredentials, Depends(get_token)],  # noqa: ARG001
+) -> None:
+    """Get Account Id by Login."""
+
+
+@router.get(
+    "/accounts/logins/match",
+    description="Check if account with provided login exists.",
+    responses={
+        status.HTTP_204_NO_CONTENT: {
+            "description": "Account with current login exists.",
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Account with current login doesn't exist.",
+        },
+    },
+    response_model=None,
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Check login uniqueness.",
+)
+async def match_account_login(
+    account_login: Annotated[schemas.AccountLogin, Body(example={"login": "john_doe"})],  # noqa: ARG001
+) -> None:
+    """Check account login uniqueness."""
+
+
+@router.get(
+    "/accounts/emails/match",
+    description="Check if account with provided email exists.",
+    responses={
+        status.HTTP_204_NO_CONTENT: {
+            "description": "Account with current email exists.",
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Account with current email doesn't exist.",
+        },
+    },
+    response_model=None,
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Check email uniqueness.",
+)
+async def match_account_email(
+    account_email: Annotated[schemas.AccountEmail, Body(example={"email": "john.doe@mail.com"})],  # noqa: ARG001
+) -> None:
+    """Check account email uniqueness."""

--- a/src/account/schemas.py
+++ b/src/account/schemas.py
@@ -18,3 +18,21 @@ class Account(Schema):
     created_at: datetime
     email: Email
     login: Login
+
+
+class AccountId(Schema):
+    """Account Id."""
+
+    id: PositiveInt  # noqa: A003
+
+
+class AccountLogin(Schema):
+    """Account login."""
+
+    login: Login
+
+
+class AccountEmail(Schema):
+    """Account email."""
+
+    email: Email

--- a/src/routes.py
+++ b/src/routes.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+import src.account.routes
 import src.auth.routes
 import src.health.routes
 
 
 router = APIRouter()
 
+router.include_router(src.account.routes.router)
 router.include_router(src.auth.routes.router)
 router.include_router(src.health.routes.router)


### PR DESCRIPTION
После того как была разработана архитектура эндпойнтов авторизации (#77), можно приступить к разработке архитектуры эндпойнтов для работы с Аккаунтом пользователя.

В рамках этой задачи необходимо разработать архитектуру эндпойнтов Аккаунта и добавить определния сваггера.

**Особенности реализации**

Т.к. роутинг на фронте работает через логин юзера, например `http://wlss.com/john_doe/friends`, в то время как REST апишка бэка использует айди, например `GET /accounts/42/friends`, то может возникнуть ситуация, когда фронт не знает айди аккаунта, и как следствие не может делать запросы на бэк. Например, если юзер просто перейдёт по прямой ссылке `http://wlss.com/john_doe/friends`, то фронт будет знать только логин юзера, но не будет знать его айди, и следовательно не сможет отправлять запросы на бэк.

Одним из решений этой проблемы могло быть использование логина в рест апишке, но это достаточно сильно повлияло бы на архитектуру бэка (в том числе и на бд), что кажется довольно большим оверхедом в данной ситуации. Поэтому было принято решение добавить специальный эндпойнт, который позволял бы обменять логин юзера на айди.

Поскольку на данный момент согласно дизайнам MVP, мы не планируем нигде выводить полную информацию об аккаунте пользователя, то сейчас нам достаточно только одного эндпойнта, который обменивает логин на айди.

Если в будущем возникнет необходимость получать полную информацию об аккаунте, то для этого придётся создать отдельный эндпойнт. Таким образом у нас будет два эндпойнта для получения информации об аккаунте - один обменивает логин юзера на айди, при этом проверка прав позволяет любому юзеру зарегистрированному в системе получить айди любого другого пользователя по его логину. Второй эндпойнт возвращает полную информацию по аккаунту пользователя, при этом проверка прав этого эндпойнта позволяет юзерам получать информацию только по своему аккаунту.