### PR TITLE
Добавить проверку lock файла в CI (#102)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -208,3 +208,27 @@ jobs:
         env:
           ENV_FILE: envs/ci/lint/.env
         uses: ./.github/actions/docker/update-buildx-cache
+
+  poetry:
+    name: Poetry
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Cache Docker layers
+        uses: ./.github/actions/docker/use-buildx-cache
+
+      - name: Create .env file
+        run: source envs/ci/lint/env.sh
+
+      - name: Build poetry
+        run: docker compose --file envs/ci/lint/docker-compose.yml build poetry
+
+      - name: Run poetry
+        run: docker compose --file envs/ci/lint/docker-compose.yml run poetry
+
+      - name: Update buildx cache
+        env:
+          ENV_FILE: envs/ci/lint/.env
+        uses: ./.github/actions/docker/update-buildx-cache

--- a/envs/ci/lint/docker-compose.yml
+++ b/envs/ci/lint/docker-compose.yml
@@ -37,3 +37,7 @@ services:
   black:
     <<: *app-build
     entrypoint: black --line-length=120 --check migrations
+
+  poetry:
+    <<: *app-build
+    entrypoint: poetry lock --check


### PR DESCRIPTION
В рамках добавления линтеров в CI (#6), мы добавили линтеры, чтобы предотвратить появление кода с ошибками линтеров в основной ветке репозитория. Но помимо самих линтеров, определённые инструменты, которые мы используем, также предлагают различные проверки, которые могут помочь нам правильно использовать эти инструменты.

Например, poetry имеет команду `poetry lock --check`, которая проверяет, что `poetry.lock` файл действительно отражает изменения, внесённые в `pyproject.toml`. Эту проверку можно добавить в CI пайплайн, чтобы предотвратить появление неконсистентных lock-файлов в основной ветке репозитория, иными словами, предотвратить наличие "несобираемых" билдов в коммитах основной ветки.

Это позволит нам не беспокоиться о консистентности lock-файлов, т.к. каждый раз когда файл оказывается в неконсистентном состоянии, CI пайплан предотвратит мердж такого файла в основную ветку.

В рамках этой задачи необходимо добавить проверку lock-файла в CI пайплайн.