### PR TITLE
Добавить в CI проверки регистрации моделей в alembic.ini (#105)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -232,3 +232,27 @@ jobs:
         env:
           ENV_FILE: envs/ci/lint/.env
         uses: ./.github/actions/docker/update-buildx-cache
+
+  models:
+    name: Models
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Cache Docker layers
+        uses: ./.github/actions/docker/use-buildx-cache
+
+      - name: Create .env file
+        run: source envs/ci/lint/env.sh
+
+      - name: Build models
+        run: docker compose --file envs/ci/lint/docker-compose.yml build models
+
+      - name: Run models
+        run: docker compose --file envs/ci/lint/docker-compose.yml run models
+
+      - name: Update buildx cache
+        env:
+          ENV_FILE: envs/ci/lint/.env
+        uses: ./.github/actions/docker/update-buildx-cache

--- a/envs/ci/lint/docker-compose.yml
+++ b/envs/ci/lint/docker-compose.yml
@@ -41,3 +41,7 @@ services:
   poetry:
     <<: *app-build
     entrypoint: poetry lock --check
+
+  models:
+    <<: *app-build
+    entrypoint: python envs/ci/lint/scripts/db/registered_models.py

--- a/envs/ci/lint/scripts/db/registered_models.py
+++ b/envs/ci/lint/scripts/db/registered_models.py
@@ -1,0 +1,79 @@
+"""This script is used to compare models existing in repository with models registered in alembic.ini file.
+
+All src/**/models.py files should be added to 'models_packages' inside alembic.ini file.
+It will allow alembic to find our models and work with migrations for those models.
+
+So this script can find any models.py file which actually exists in repository but not registered in alembic.ini,
+and also find any models.py file which is registered in alembic.ini but does not exist in repository.
+"""
+
+import os
+import sys
+from configparser import ConfigParser
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).parents[5]
+
+
+def main():
+    used_packages = set(get_used_models_packages())
+    registered_packages = set(get_registered_models_packages())
+
+    missed_packages = registered_packages - used_packages
+    if missed_packages:
+        print_missed_packages_error(missed_packages)
+
+    redundant_packages = used_packages - registered_packages
+    if redundant_packages:
+        print_redundant_packages_error(redundant_packages)
+
+    if not missed_packages and not redundant_packages:
+        print("All models registered in alembic.ini correctly.")
+        sys.exit(0)
+
+    sys.exit(1)
+
+
+def get_registered_models_packages():
+    """Get models packages registered in 'models_packages' section of alembic.ini file."""
+    config = ConfigParser(allow_no_value=True)
+    config.read(PROJECT_ROOT / "alembic.ini")
+
+    for package_path in config["alembic"]["models_packages"].split(","):
+        package_path = package_path.strip()
+        if package_path:
+            yield package_path
+
+
+def get_used_models_packages():
+    """Get all models packages existing inside src/ directory."""
+    for path in (PROJECT_ROOT / "src").glob("**/models.py"):
+        path = str(path.relative_to(PROJECT_ROOT))
+        path = path[:-3]  # cut off ".py" extension
+        package_path = path.replace(os.sep, ".")
+        yield package_path
+
+
+def print_redundant_packages_error(packages):
+    print(
+        "\n"
+        "ERROR Following packages should be added to 'models_packages' in alembic.ini file\n"
+        "since they are used but not registered:"
+        "\n"
+    )
+    print("\n".join(packages), end="\n\n")
+
+
+def print_missed_packages_error(packages):
+    print(
+        "\n"
+        "ERROR Following packages should be removed from 'models_packages' in alembic.ini file\n"
+        "since they are registered but not used:"
+        "\n"
+    )
+    print("\n".join(packages), end="\n\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
В рамках задачи добавления PostgreSQL (#29) мы добавили в конфигурацию алембика параметр `models_packages`, в котором необходимо явно перечислить пути до пакетов с моделями, чтобы алембик мог о них узнать до того как начнёт работу с этими моделями. "Знакомство" алембика с этими моделями производится через импорт этих моделей в файле `migrations/env.py` перед началом выполнения/генерирования миграций.

Это означает, что, например, если разработчик создаст файл `src/account/models.py` и добавит туда модели, но не пропишет путь до этого файла в `models_packages` в файле `alembic.ini`, то алембик не сможет создать миграцию для этих моделей.

Чтобы предотвратить появление таких незарегистрированных моделей в основной ветке репозитория, можно добавить в CI проверку, которая будет сравнивать зарегистрированные пакеты моделей и реально существующие в репозитории.

В рамках этой задачи необходимо добавить в CI возможность проверять все ли модели зарегистрированы в конфигурационном файле алембика, а также проверять файлы, которые зарегистрированы, но больше не существуют в репозитории.