### PR TITLE
Добавить проверки алембика в CI (#78)

### DIFF
--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -1,0 +1,31 @@
+name: Database
+run-name: Check database for commit "${{ github.sha }}"
+
+on:
+  push:
+    branches:
+      - "*"
+jobs:
+  alembic:
+    name: Alembic
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Cache Docker layers
+        uses: ./.github/actions/docker/use-buildx-cache
+
+      - name: Create .env file
+        run: source envs/ci/db/env.sh
+
+      - name: Build alembic
+        run: docker compose --file envs/ci/db/docker-compose.yml build
+
+      - name: Run alembic
+        run: docker compose --file envs/ci/db/docker-compose.yml up --attach alembic --exit-code-from alembic
+
+      - name: Update buildx cache
+        env:
+          ENV_FILE: envs/ci/db/.env
+        uses: ./.github/actions/docker/update-buildx-cache

--- a/envs/ci/db/Dockerfile
+++ b/envs/ci/db/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+    # we need 'enchant-2' for pylint's spellchecker
+    && apt-get -y install enchant-2 \
+    && pip install --upgrade pip \
+    && pip install poetry==1.4.2
+
+RUN poetry config virtualenvs.create false
+
+COPY poetry.lock pyproject.toml ./
+
+RUN poetry install --with=dev
+
+COPY . ./

--- a/envs/ci/db/docker-compose.yml
+++ b/envs/ci/db/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.8"
+
+name: wlss-ci-db
+
+services:
+  app-build: &app-build
+    build:
+      context: ../../..  # path from the corrent file to the project root dir
+      dockerfile: envs/ci/db/Dockerfile  # path from the project root dir to the Dockerfile
+      cache_from:
+        - type=local,src=${BUILDX_CACHE_SRC}
+      cache_to:
+        - type=local,dest=${BUILDX_CACHE_DEST}
+
+  alembic:
+    <<: *app-build
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      - WLSS_ENV=ci/db
+    entrypoint: |
+      bash -c "
+        alembic upgrade head
+        alembic check
+      "
+
+  postgres:
+    image: postgres:latest
+    env_file:
+      - .env
+    healthcheck:
+      # see: https://github.com/peter-evans/docker-compose-healthcheck#waiting-for-postgresql-to-be-healthy
+      test: [ "CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+      interval: 5s
+      retries: 10
+    volumes:
+      - postgres:/var/lib/postgresql/data
+
+volumes:
+  postgres:

--- a/envs/ci/db/env.sh
+++ b/envs/ci/db/env.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ENV_FILE=$SCRIPT_DIR/.env
+
+# ======================================================================================================================
+
+# The environment vairables below will be written
+# to the .env file in the directory along with this script.
+
+# Please keep environment variables in the current script
+# alphabetically sorted and use double quotes around the values.
+
+# You can read more why we need to use quotes here:
+# https://stackoverflow.com/a/71538763/8431075
+
+cat > $ENV_FILE << EOF
+BUILDX_CACHE_DEST="/tmp/.buildx-cache-new"
+BUILDX_CACHE_SRC="/tmp/.buildx-cache"
+
+# Minio related variables are not used for envs/ci/db checks
+# because we don't need to connect to minio to check db-related stuff.
+# But these variables are required by the application config.
+# And since alembic uses application config to connect to db
+# we need to provide them even if they're not used in this case.
+MINIO_HOST="minio"
+MINIO_PORT="9000"
+MINIO_ROOT_PASSWORD="minioadmin"
+MINIO_ROOT_USER="minioadmin"
+MINIO_SCHEMA="HTTP"
+
+POSTGRES_DB="postgres"
+POSTGRES_HOST="postgres"
+POSTGRES_PASSWORD="postgres"
+POSTGRES_PORT="5432"
+POSTGRES_USER="postgres"
+EOF
+
+# ======================================================================================================================
+
+cat << EOF
+
+Default environment variables has been written to:
+$ENV_FILE
+
+This setup should just work fine right out of the box,
+but you can adjust this file in the way you want.
+
+EOF


### PR DESCRIPTION
Чтобы предотвратить появление изменений в моделях, которые не отражены в миграциях, алембик предоставляет команду `alembic check` (см. [доку](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#running-alembic-check-to-test-for-new-upgrade-operations)).

В рамках этой задачи необходимо добавить запуск этой команды в CI пайплайне, чтобы предотвратить появление коммитов без необходимых миграций в основной ветке репозитория.

**Детали реализации**

Поскольку работа алембика требует наличие базы данных, то мы не можем добавить эти проверки в тот же докер компоуз файл, где содержатся проверки линтеров (`envs/ci/lint/docker-compose.yml`), т.к. все сервисы из этого файла запускаются в отдельных джобах CI через `docker-compose ... start` и каждый сервис является самодостаточным. Мы не можем добавить туда сервис с алембиком и базой данных, потому что в таком случае пришлось бы запускать их через `docker-compose ... up` и все сервисы оказались бы запущены в одной джобе.

Также мы не можем добавить проверку алембика в компоуз-файл связанный с запуском юнит-тестов (`envs/ci/test/docker-compose.yml`), т.к. для юнит-тестов нужен ещё и minio, а для алембика он не нужен. Также тестовая бд должна быть чистой, изолированной и использоваться только для тестов, поэтому параллельная работа алембика с той же бд, на которой запускаются тесты, может повлиять на работу этих тестов.

В связи с этим было принято решение вынести проверку алембика в отдельный файл (`envs/ci/db/docker-compose.yml`), где будет подниматься сервис с базой данных и сервис с алембиком.