### PR TITLE
Добавить идентификатор проекта в пропущенных местах (#109)

### DIFF
--- a/envs/ci/db/Dockerfile
+++ b/envs/ci/db/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 
-WORKDIR /app
+WORKDIR /wlss-backend
 
 RUN apt-get update \
     # we need 'enchant-2' for pylint's spellchecker

--- a/envs/ci/lint/docker-compose.yml
+++ b/envs/ci/lint/docker-compose.yml
@@ -16,14 +16,14 @@ services:
     <<: *app-build
     volumes:
       # bind .mypy_cache to the host in order to store mypy cache in GitHub Cache
-      - ../../../.mypy_cache:/app/.mypy_cache  # host path is relative to the current docker-compose file
+      - ../../../.mypy_cache:/wlss-backend/.mypy_cache  # host path is relative to the current docker-compose file
     entrypoint: mypy
 
   ruff:
     <<: *app-build
     volumes:
       # bind .ruff_cache to the host in order to store ruff cache in GitHub Cache
-      - ../../../.ruff_cache:/app/.ruff_cache  # host path is relative to the current docker-compose file
+      - ../../../.ruff_cache:/wlss-backend/.ruff_cache  # host path is relative to the current docker-compose file
     entrypoint: ruff check src tests
 
   flake8:

--- a/envs/ci/test/Dockerfile
+++ b/envs/ci/test/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 
-WORKDIR /app
+WORKDIR /wlss-backend
 
 RUN apt-get update \
     # we need 'enchant-2' for pylint's spellchecker

--- a/envs/ci/test/docker-compose.yml
+++ b/envs/ci/test/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - WLSS_ENV=ci/test
     volumes:
       # bind .pytest_cache to the host in order to store pytest cache in GitHub Cache
-      - ../../../.pytest_cache:/app/.pytest_cache  # host path is relative to the current docker-compose file
+      - ../../../.pytest_cache:/wlss-backend/.pytest_cache  # host path is relative to the current docker-compose file
     entrypoint: pytest --cov=src
 
   postgres:


### PR DESCRIPTION
В рамках работы над задачей добавления идентификатора проекта (#42), были допущены некоторые ошибки.

Например, в файле `envs/ci/lint/Dockerfile` команда `WORKDIR` была заменена:
```Dockerfile
# с этой
WORKDIR /app

# на эту
WORKDIR /wlss-backend
```

Но при этом в файле `envs/ci/lint/docker-compose` строчка, которая связывает волюм кэша майпая не была заменена:

```yaml
# строчка осталась такой
- ../../../.mypy_cache:/app/.mypy_cache

# а должна была быть такой
- ../../../.mypy_cache:/wlss-backend/.mypy_cache
```

Из-за этого наш CI пайплан перестал сохранять кэш майпая, а точнее он сохранял пустой кэш, т.к. в папке `/app/.mypy_cache` в контейнере кэша уже не было, он был в `/wlss-backend/.mypy_cache`.

Аналогичная проблема возникла и с раффом.

Также не совсем понятно, почему команда `WORKDIR` была изменена только в одном докерфайле - `envs/ci/lint/Dockerfile`, и при этом не изменена в другом - `envs/ci/test/Dockerfile`.

Из этого последовало то, что при добавлении проверок алембика в CI (#78) в `envs/ci/db/Dockerfile`, была прописана команда `WORKDIR /app`, т.к. при работе над задачей за основу была взята конфигурация из `envs/ci/test/...`.

Следовательно, на данный момент у нас есть две проблемы, связанные с ошибками, допущенными при добавлении идентификатора:
1. Неправильно работающее кэширование на CI.
2. Неконсистентные значения для команды `WORKDIR` в разных докерфайлах.

В рамках этой задачи необходимо поправить все команды `WORKDIR` так, чтобы они указывали на папку `/wlss-backend`, а так же поправить все команды `volumes`, чтобы они также указывали на `/wlss-backend`.