### PR TITLE
 Изменить группировку зависимостей в pyproject.toml (#111)

### DIFF
--- a/.github/actions/docker/use-buildx-cache/action.yml
+++ b/.github/actions/docker/use-buildx-cache/action.yml
@@ -11,7 +11,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
-        key: buildx-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+        key: buildx-${{ env.CACHE_KEY_PREFIX }}-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
         restore-keys: |
-          buildx-${{ runner.os }}-${{ github.ref_name }}
-          buildx-${{ runner.os }}-${{ github.event.repository.default_branch }}
+          buildx-${{ env.CACHE_KEY_PREFIX }}-${{ runner.os }}-${{ github.ref_name }}
+          buildx-${{ env.CACHE_KEY_PREFIX }}-${{ runner.os }}-${{ github.event.repository.default_branch }}

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
+        env:
+          CACHE_KEY_PREFIX: 'envs-ci-db'  # prefix should match directory which contains Dockerfile used for build
 
       - name: Create .env file
         run: source envs/ci/db/env.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
+        env:
+          CACHE_KEY_PREFIX: 'envs-ci-lint'  # prefix should match directory which contains Dockerfile used for build
 
       - name: Cache mypy
         uses: actions/cache@v3
@@ -65,6 +67,8 @@ jobs:
 
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
+        env:
+          CACHE_KEY_PREFIX: 'envs-ci-lint'  # prefix should match directory which contains Dockerfile used for build
 
       - name: Cache ruff
         uses: actions/cache@v3
@@ -114,6 +118,8 @@ jobs:
 
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
+        env:
+          CACHE_KEY_PREFIX: 'envs-ci-lint'  # prefix should match directory which contains Dockerfile used for build
 
       - name: Create .env file
         run: source envs/ci/lint/env.sh
@@ -154,6 +160,8 @@ jobs:
 
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
+        env:
+          CACHE_KEY_PREFIX: 'envs-ci-lint'  # prefix should match directory which contains Dockerfile used for build
 
       - name: Create .env file
         run: source envs/ci/lint/env.sh
@@ -194,6 +202,8 @@ jobs:
 
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
+        env:
+          CACHE_KEY_PREFIX: 'envs-ci-lint'  # prefix should match directory which contains Dockerfile used for build
 
       - name: Create .env file
         run: source envs/ci/lint/env.sh
@@ -218,6 +228,8 @@ jobs:
 
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
+        env:
+          CACHE_KEY_PREFIX: 'envs-ci-lint'  # prefix should match directory which contains Dockerfile used for build
 
       - name: Create .env file
         run: source envs/ci/lint/env.sh
@@ -242,6 +254,8 @@ jobs:
 
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
+        env:
+          CACHE_KEY_PREFIX: 'envs-ci-lint'  # prefix should match directory which contains Dockerfile used for build
 
       - name: Create .env file
         run: source envs/ci/lint/env.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
+        env:
+          CACHE_KEY_PREFIX: 'envs-ci-test'  # prefix should match directory which contains Dockerfile used for build
 
       - name: Cache pytest
         uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ source envs/local/dev/scripts/git/iam.sh
 
 2. Create virtual environment and install dependencies.
 ```bash
-poetry install --with dev
+poetry install --with app,lint,test
 ```
 
 3. Activate virtual environment.

--- a/envs/ci/db/Dockerfile
+++ b/envs/ci/db/Dockerfile
@@ -12,6 +12,6 @@ RUN poetry config virtualenvs.create false
 
 COPY poetry.lock pyproject.toml ./
 
-RUN poetry install --with=dev
+RUN poetry install --with=app,lint
 
 COPY . ./

--- a/envs/ci/lint/Dockerfile
+++ b/envs/ci/lint/Dockerfile
@@ -12,6 +12,8 @@ RUN poetry config virtualenvs.create false
 
 COPY poetry.lock pyproject.toml ./
 
-RUN poetry install --with=dev
+# we also need to install 'test' dependencies here, because linters check tests code as well
+# otherwise linters will report 'module not found' errors for tests code
+RUN poetry install --with=app,lint,test
 
 COPY . ./

--- a/envs/ci/test/Dockerfile
+++ b/envs/ci/test/Dockerfile
@@ -12,6 +12,6 @@ RUN poetry config virtualenvs.create false
 
 COPY poetry.lock pyproject.toml ./
 
-RUN poetry install --with=dev
+RUN poetry install --with=app,test
 
 COPY . ./

--- a/envs/test/Dockerfile
+++ b/envs/test/Dockerfile
@@ -12,6 +12,6 @@ RUN poetry config virtualenvs.create false
 
 COPY poetry.lock pyproject.toml ./
 
-RUN poetry install --with=deploy
+RUN poetry install --with=app,deploy
 
 COPY . ./

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,7 +4,7 @@
 name = "alembic"
 version = "1.10.4"
 description = "A database migration tool for SQLAlchemy."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -25,7 +25,7 @@ tz = ["python-dateutil"]
 name = "anyio"
 version = "3.6.2"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6.2"
 files = [
@@ -80,7 +80,7 @@ test = ["astroid", "pytest"]
 name = "asyncpg"
 version = "0.27.0"
 description = "An asyncio PostgreSQL driver"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7.0"
 files = [
@@ -179,7 +179,7 @@ uvloop = ["uvloop (>=0.15.2)"]
 name = "certifi"
 version = "2022.12.7"
 description = "Python package for providing Mozilla's CA Bundle."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -191,7 +191,7 @@ files = [
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -206,7 +206,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
-category = "main"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 files = [
@@ -323,7 +323,7 @@ flake8 = ">=3.6.0"
 name = "dnspython"
 version = "2.3.0"
 description = "DNS toolkit"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
@@ -356,7 +356,7 @@ files = [
 name = "email-validator"
 version = "1.3.1"
 description = "A robust email address syntax and deliverability validation library."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
 files = [
@@ -372,7 +372,7 @@ idna = ">=2.0.0"
 name = "fastapi"
 version = "0.95.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -596,7 +596,7 @@ flake8 = ">3.0.0"
 name = "greenlet"
 version = "2.0.2"
 description = "Lightweight in-process concurrent programming"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 files = [
@@ -691,7 +691,7 @@ tornado = ["tornado (>=0.2)"]
 name = "h11"
 version = "0.14.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -703,7 +703,7 @@ files = [
 name = "httpcore"
 version = "0.17.0"
 description = "A minimal low-level HTTP client."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -725,7 +725,7 @@ socks = ["socksio (>=1.0.0,<2.0.0)"]
 name = "httptools"
 version = "0.5.0"
 description = "A collection of framework independent HTTP protocol utils."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.5.0"
 files = [
@@ -779,7 +779,7 @@ test = ["Cython (>=0.29.24,<0.30.0)"]
 name = "httpx"
 version = "0.24.0"
 description = "The next generation HTTP client."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -803,7 +803,7 @@ socks = ["socksio (>=1.0.0,<2.0.0)"]
 name = "idna"
 version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
 files = [
@@ -845,7 +845,7 @@ requirements-deprecated-finder = ["pip-api", "pipreqs"]
 name = "itsdangerous"
 version = "2.1.2"
 description = "Safely pass data to untrusted environments and back."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -857,7 +857,7 @@ files = [
 name = "jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -921,7 +921,7 @@ files = [
 name = "mako"
 version = "1.2.4"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -941,7 +941,7 @@ testing = ["pytest"]
 name = "markupsafe"
 version = "2.1.2"
 description = "Safely add untrusted strings to HTML/XML markup."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1013,7 +1013,7 @@ files = [
 name = "minio"
 version = "7.1.14"
 description = "MinIO Python SDK for Amazon S3 Compatible Cloud Storage"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 files = [
@@ -1104,7 +1104,7 @@ files = [
 name = "orjson"
 version = "3.8.10"
 description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">= 3.7"
 files = [
@@ -1173,7 +1173,7 @@ files = [
 name = "overrides"
 version = "7.3.1"
 description = "A decorator to automatically detect mismatch when overriding a method."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -1253,7 +1253,7 @@ files = [
 name = "pydantic"
 version = "1.10.7"
 description = "Data validation and settings management using python type hints"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1491,7 +1491,7 @@ test = ["coverage (>=6.5)", "pytest-mock (>=3.10)"]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
@@ -1506,7 +1506,7 @@ six = ">=1.5"
 name = "python-dotenv"
 version = "1.0.0"
 description = "Read key-value pairs from a .env file and set them as environment variables"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
@@ -1521,7 +1521,7 @@ cli = ["click (>=5.0)"]
 name = "python-multipart"
 version = "0.0.6"
 description = "A streaming multipart parser for Python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1536,7 +1536,7 @@ dev = ["atomicwrites (==1.2.1)", "attrs (==19.2.0)", "coverage (==6.5.0)", "hatc
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -1644,7 +1644,7 @@ testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 files = [
@@ -1656,7 +1656,7 @@ files = [
 name = "sniffio"
 version = "1.3.0"
 description = "Sniff out which async library your code is running under"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1680,7 +1680,7 @@ files = [
 name = "sqlalchemy"
 version = "2.0.12"
 description = "Database Abstraction Library"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1758,7 +1758,7 @@ sqlcipher = ["sqlcipher3-binary"]
 name = "starlette"
 version = "0.26.1"
 description = "The little ASGI library that shines."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1815,7 +1815,7 @@ files = [
 name = "typing-extensions"
 version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1827,7 +1827,7 @@ files = [
 name = "ujson"
 version = "5.7.0"
 description = "Ultra fast JSON encoder and decoder for Python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1902,7 +1902,7 @@ files = [
 name = "urllib3"
 version = "2.0.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1920,7 +1920,7 @@ zstd = ["zstandard (>=0.18.0)"]
 name = "uvicorn"
 version = "0.21.1"
 description = "The lightning-fast ASGI server."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1946,7 +1946,7 @@ standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)",
 name = "uvloop"
 version = "0.17.0"
 description = "Fast implementation of asyncio event loop on top of libuv"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1991,7 +1991,7 @@ test = ["Cython (>=0.29.32,<0.30.0)", "aiohttp", "flake8 (>=3.9.2,<3.10.0)", "my
 name = "watchfiles"
 version = "0.19.0"
 description = "Simple, modern and high performance file watching and code reload in python."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -2026,7 +2026,7 @@ anyio = ">=3.0.0"
 name = "websockets"
 version = "11.0.1"
 description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -2190,4 +2190,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "b879d9c7ed4bd92f0eb8c501200870642174df6a8986ec014887e588999935d0"
+content-hash = "94601396d8830f56a5a83518d33a6fa7f3f0a116f21db8979ecd6eebb19fbaba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,14 @@ version = "0.0.0"
 
 python = "~3.11"
 
+
+[tool.poetry.group.app]
+
+optional = true
+
+
+[tool.poetry.group.app.dependencies]
+
 alembic = {extras = ["tz"], version = "1.10.4"}
 asyncpg = "0.27.0"  # asynchronous postgresql driver used by sqlalchemy
 fastapi = {extras = ["all"], version = "0.95.0" }  # we need "all" at least for uvicorn
@@ -25,11 +33,12 @@ python-dotenv = "1.0.0"
 sqlalchemy = {extras = ["asyncio"], version = "2.0.12"}
 
 
-[tool.poetry.group.dev]
+[tool.poetry.group.lint]
 
 optional = true
 
-[tool.poetry.group.dev.dependencies]
+
+[tool.poetry.group.lint.dependencies]
 
 black = "23.3.0"
 darglint = "1.8.1"  # Checks whether a docstring's description matches the actual function/method implementation
@@ -51,11 +60,20 @@ pyenchant = "3.2.2"  # needed for pylint's spellchecker
 pylint = "2.17.2"
 pylint-per-file-ignores = "1.2.0"  # A pylint plugin to ignore error codes per file.
 pylint-pydantic = "0.1.8"  # A Pylint plugin to help Pylint understand the Pydantic.
+ruff = "0.0.261"
+types-ujson = "5.7.0.5"  # types for mypy
+
+
+[tool.poetry.group.test]
+
+optional = true
+
+
+[tool.poetry.group.test.dependencies]
+
 pytest = "7.3.0"
 pytest-cov = "4.0.0"
 pytest-env = "0.8.1"  # needed to set up default $WLSS_ENV for tests execution
-ruff = "0.0.261"
-types-ujson = "5.7.0.5"  # types for mypy
 
 
 [tool.poetry.group.deploy]


### PR DESCRIPTION
На данный момент зависимости проекта сгруппированы следующи:
- **main** - зависимости для работы самого проекта + версия python
- **dev** - зависимости для линтинга и юнит-тестирования
- **deploy** - зависимости необходимые при деплое на стенд

Это разбиение имеет ряд недостатков:

- **main** Несмотря на то, что все зависимости у нас отсортированы в алфавитном порядке для удобства поиска, версия python отделена от остальных зависимостей. Это было сделано для того, чтобы явно выделить её и при необходимости не искать среди множества зависимостей. Это разделение можно сделать более явным если выделить зависимости приложения в отдельную группу - app. Таким образом в main останется только версия интерпретатора, а все зависимости проекта будут лежать в app.

- **dev** Эта группа содержит в себе зависимости для разных типов задач - линтинга и тестирования. И название "dev" не очень явно отражает смысл зависимостей перечисленных в этой группе. Чтобы сделать этот смысл более явным, можно разделить зависимости из группы "dev" на две группы - "lint" и "test", в каждой из них будут зависимости для своего типа задач - линтинга и тестирования, соответственно.

Таким образом в рамках этой задачи необходимо:
1. реализовать следующую группировку зависимостей:
   - **main** - версия python
   - **app** - зависимости проекта
   - **lint** - зависимости для линтинга
   - **test** - зависимости для тестирования
   - **deploy** - зависимости для деплоя

2. Обновить все места, где прописана установка зависимостей - ридми и докерфайлы.
3. Изменить ключи кэширования сборок докера, т.к. на данный момент все сборки кэшируются по ключу `buildx-...`, но поскольку в каждой из сборок - lint, test, deploy - теперь будет разный набор зависимостей, необходимо кэшировать их под разными ключами. Например, `buildx-envs-ci-lint-...`, `build-envs-ci-test-...`, `buildx-envs-ci-deploy-...`.