### PR TITLE
Убрать ограничения длины из регулярок полей (#117)

### DIFF
--- a/src/profile/fields.py
+++ b/src/profile/fields.py
@@ -15,7 +15,7 @@ class Description(StrField):
     FIELD_NAME = "Profile Description"
     LENGTH_MAX = 1000
     LENGTH_MIN = 1
-    REGEXP = r".{1,1000}"
+    REGEXP = r".*"
 
 
 class Name(StrField):


### PR DESCRIPTION
В рамках добавления сваггера для эндпойнта авторизации (#77) были добавлены схемы запросов и ответов, а также схемы полей для pydantic схем.

Для строковых полей `StrField` были определены атрибуты `FIELD_NAME`, `LENGTH_MAX`, `LENGTH_MIN` и `REGEXP`. Несмотря на то, что ограничения длины строкового значения можно было бы указать в регулярке, они специально были вынесены в отдельные аттрибуты `LENGTH_MAX` и `LENGTH_MIN`. Это было сделано по следующим причинам:
1. Для более четкого разделения ошибок - если значение поля не подходит по длине, об этом должна быть отдельная ошибка.
2. Вынесение ограничений длины в отдельные константы позволит использовать эти константы где-либо ещё. Если же длина была бы зашита в регулярку, то чтобы возпользоваться значением длины поля в другом месте в коде, необходимо было бы парсить регулярку.
3. (возможно в этом нет смысла) Защита подсистемы регулярных выражений от слишком больших инпутов. Это может быть полезно, т.к. некоторые реализации систем регулярных выражений используют recursive backtracking алгоритм, который имеет экспоненциальную сложность зависящую от размера входящей строки.

Но в процессе работы над #77 в регулярку описания профиля пользователя было добавлено ограничение длины:
```python
class Description(StrField):
    """Description value field."""

    FIELD_NAME = "Profile Description"
    LENGTH_MAX = 1000
    LENGTH_MIN = 1
    REGEXP = r".{1,1000}"
```

Таким образом в рамках это задачи необходимо убрать ограничение длины из регулярного выражения поля `Description`.