### PR TITLE
Вынести функциональность из pytest_sessionstart (#119)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
 
 import pytest
-from alembic.config import main as alembic
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import async_scoped_session, async_sessionmaker, create_async_engine
 
@@ -17,18 +15,9 @@ from src.shared.minio import get_minio
 from tests.utils.database import set_autoincrement_counters
 
 
-if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncSession
-
-
-def pytest_sessionstart(session: AsyncSession):
-    """Pytest initialization hook.
-
-    Called after the Session object has been created and before performing collection and entering the run test loop.
-
-    :param session: The pytest session object.
-    """
-    alembic(["upgrade", "head"])
+@pytest.fixture(scope="session", autouse=True)
+def _initialize_db():
+    """Prepare database before test run."""
     set_autoincrement_counters()
 
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -19,6 +19,9 @@ auth
 # auto increment
 autoincrement
 
+# auto use (from pytest library)
+autouse
+
 # class method (pylint spellcheck)
 classmethod
 


### PR DESCRIPTION
В процессе работы с миграциями было замечено странное поведение - после генерирования новой миграции (`alembic revision --autogenerate ...`) она автоматически применялась к базе данных - без явного вызова `alembic upgrade head`.

Оказалось, что такое поведение связано, с особенностями работы вскода, при работе в котором и проявлялось это странное поведение, а также с нашей функцией `pytest_sessionstart`:
```python
def pytest_sessionstart(session: AsyncSession):
    """Pytest initialization hook.

    Called after the Session object has been created and before performing collection and entering the run test loop.

    :param session: The pytest session object.
    """
    alembic(["upgrade", "head"])
    set_autoincrement_counters()
```

Поскольку эта функция вызывается перед началом сбора тестов, то как оказалось, вскод сам вызывает её, чтобы собрать тесты для удобного отображения на вкладке с тестами.

Это значит, что при работе с вскодом тестовая база данных всегда будет на последней созданной миграции. И поскольку могут возникать ситуации, когда разработчик захочет запустить тесты не на самой последней миграции, и при этом использовать вскод, то необходимо исправить это поведение.

Для этого было принято решение просто убрать автоматическое применение миграций из кода тестов. Миграции всегда должны будут применяться руками, в рамках настройки тестового окружения (поднять контейнеры, применить миграции, запустить тесты).

Чтобы избежать подобных неявных проблем с `set_autoincrement_counters` в будущем, было принято решение перенести вызов этой функции в фикстуру, которая будет автоматически вызываться перед запуском тестов, но уже после окончания test discovery:
```python
@pytest.fixture(scope="session", autouse=True)
def init_db():
    set_autoincrement_counters()
```

Таким образом рамках этой задачи необходимо убрать автоматическое применение миграций из кода тестов а также перенести `set_autoincrement_counters` в фикстуру.