### PR TITLE
Добавить удаление ранов cleanup workflow в CI (#121)

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -64,3 +64,29 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python envs/ci/cleanup/rebased_branch.py
+
+  previous-runs:
+    # This job is used to remove old runs of cleanup workflow itself.
+
+    # we don't want to remove failed runs of cleanup workflow to make their troubleshooting possible
+    if: ${{ needs.cleanup-on-delete.result != 'failure' && needs.cleanup-on-force-push.result != 'failure' }}
+    name: Previous cleanup runs
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -r ./envs/ci/cleanup/requirements.txt
+
+      - name: Run script
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 ./envs/ci/cleanup/previous_runs.py

--- a/envs/ci/cleanup/deleted_branch.py
+++ b/envs/ci/cleanup/deleted_branch.py
@@ -25,10 +25,6 @@ def main():
     for run in repository.get_workflow_runs(branch=DELETED_BRANCH_NAME):
         run.delete()
 
-    # clean up the old runs of this workflow as well
-    for run in repository.get_workflow_runs(event="delete"):
-        run.delete()
-
 
 if __name__ == "__main__":
     main()

--- a/envs/ci/cleanup/previous_runs.py
+++ b/envs/ci/cleanup/previous_runs.py
@@ -1,0 +1,31 @@
+"""Clean-up script which removes cleanup workflow's previous runs.
+
+Delete previous workflow runs of cleanup.yml.
+"""
+
+import os
+from pathlib import Path
+
+from github import Github
+
+
+GITHUB_REPOSITORY = os.environ["GITHUB_REPOSITORY"]
+GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+WORKFLOW_FILE = "cleanup.yml"
+
+
+ROOT_DIR = Path(__file__).parents[3]
+# check that workflow has been renamed or removed
+if not (ROOT_DIR / ".github" / "workflows" / WORKFLOW_FILE).exists():
+    raise FileNotFoundError("Workflow file does not exist!")
+
+
+def main():
+    repository = Github(GITHUB_TOKEN).get_repo(GITHUB_REPOSITORY)
+    cleanup_workflow = repository.get_workflow(WORKFLOW_FILE)
+    for run in cleanup_workflow.get_runs():
+        run.delete()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
После того как мы добавили пайплайн очистки в CI (#8), наши раны для коммитов перезаписаных форспушем, или для коммитов из удалённых веток, стали удаляться автоматически. Но при этом раны самого cleanup ворклфлоу, для существующих веток всё ещё сохраняются.

Кажется, нет особой нужды их хранить, поэтому можно добавить отдельную джобу, которая будет удалять раны самого cleanup воркфлоу. Таким образом на вкладке Actions у нас всегда будут только актуальные раны для актуальных коммитов и при этом всего один (последний) ран cleanup воркфлоу.

Таким образом в рамках этой задачи необходимо добавить ещё одну джобу в cleanup воркфлоу, которая будет удалять все предыдущие раные этого воркфлоу.