### PR TITLE
Отрефакторить функцию работающую с WLSS_ENV (#122)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,6 +8,9 @@ exclude =
     __pycache__,
 
 ignore =
+   # line break before binary operator
+   W503
+
     # options below are ignored because they are already implemented in ruff
     # if you want to ignored another error for some reason, please do it in a separate section above
     # =========

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,6 +1,7 @@
 ignore = [
     "D203",  # ignores D203 (one-blank-line-before-class) since we use D211 (no-blank-line-before-class)
     "D213",  # ignores D213 (multi-line-summary-second-line) since we use D212 (multi-line-summary-first-line)
+    "S101",  # ignores S101 since we don't use python optimizations with "-O"
 ]
 
 line-length = 120

--- a/src/config.py
+++ b/src/config.py
@@ -6,7 +6,7 @@ from typing import Any, TYPE_CHECKING, TypeVar
 
 from pydantic import BaseSettings, validator
 
-from src.shared.environment import load_environment
+from src.shared.environment import get_dotenv_path
 from src.shared.types import UrlSchema
 
 
@@ -17,9 +17,6 @@ if TYPE_CHECKING:
 
 
 T = TypeVar("T", bound=Any)
-
-
-load_environment()
 
 
 class _Config(BaseSettings):
@@ -41,6 +38,7 @@ class _Config(BaseSettings):
         """Pydantic's special class to configure pydantic models."""
 
         allow_mutation = False  # app config should be immutable
+        env_file = get_dotenv_path()
 
     @validator("*")
     def validate_types(cls: type[_Config], value: T, field: ModelField) -> T:  # pragma: no cover

--- a/src/shared/environment.py
+++ b/src/shared/environment.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING
-
-from dotenv import load_dotenv
 
 from src import PROJECT_ROOT
 
@@ -14,31 +13,54 @@ if TYPE_CHECKING:
     from typing import Final
 
 
-def load_environment() -> None:  # pragma: no cover
-    """Load environment variables from dotenv file provided via $WLSS_ENV environment variable.
+def get_dotenv_path() -> Path:  # pragma: no cover
+    """Get path to dotenv file resolved from $WLSS_ENV environment variable.
 
-    The value of $ENV variable should be one of those (listed in resolution order):
+    The value of $WLSS_ENV variable should be one of those (listed in resolution order):
+
         - path to a directory containing `.env` file relative to `PROJECT_ROOT/envs/`
-        - path to a dotenv file relative to `PROJECT_ROOT/envs/`
+          example: "local/dev"
+
+        - path to a particular dotenv file relative to `PROJECT_ROOT/envs/`
+          example: "local/dev/.my-env"
+
         - path to a directory containing `.env` file relative to `PROJECT_ROOT/`
+          example: "envs/local/dev"
+
         - path to a dotenv file relative to `PROJECT_ROOT/`
+          example: "envs/local/dev/.my-env"
 
-    :raises InvalidEnvironment:  raised if $WLSS_ENV environment variable isn't set
+        - absolute path to directory containing `.env` file
+          example: "/home/john/"
+
+        - absolute path to directory containing `.env` file
+          example: "/home/john/"
+
+        - absolute path to particular dotenv file
+          example: "/home/john/.my-env"
+
+    :returns: path to dotenv file
+
+    :raises AssertionError: raised if $WLSS_ENV is not provided
+    :raises FileNotFoundError: raised if dotenv file not found
     """
-    if "WLSS_ENV" not in os.environ:
-        msg = "Cannot load environment variables. Please define $WLSS_ENV environment variable."
-        raise InvalidEnvironment(msg)
-
+    assert "WLSS_ENV" in os.environ, "Can not load environment variables. Please define $WLSS_ENV environment variable."
     WLSS_ENV: Final = os.environ["WLSS_ENV"]  # noqa: N806
 
-    envs_relative_path = PROJECT_ROOT / "envs" / WLSS_ENV
-    root_relative_path = PROJECT_ROOT / WLSS_ENV
-    dotenv_path = envs_relative_path if envs_relative_path.exists() else root_relative_path
+    paths_to_resolve = (
+        PROJECT_ROOT / "envs" / WLSS_ENV / ".env",
+        PROJECT_ROOT / "envs" / WLSS_ENV,
+        PROJECT_ROOT / WLSS_ENV / ".env",
+        PROJECT_ROOT / WLSS_ENV,
+        Path(WLSS_ENV) / ".env",
+        Path(WLSS_ENV),
+    )
+    for path in paths_to_resolve:
+        if path.is_file():
+            return path
 
-    if dotenv_path.is_dir():
-        dotenv_path = dotenv_path / ".env"
-    load_dotenv(dotenv_path, override=True)
-
-
-class InvalidEnvironment(Exception):  # noqa: N818
-    """Raised if there were errors during environment variables loading."""
+    raise FileNotFoundError(
+        "Cannot find dotenv file resolved from $WLSS_ENV variable.\n"
+        "Tried following paths:\n"
+        + "\n".join(str(path) for path in paths_to_resolve),
+    )

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -31,6 +31,9 @@ config
 # designates files with `.env` extension
 dotenv
 
+# development (pylint spellcheck)
+dev
+
 # enumeration (pylint spellcheck)
 enum
 


### PR DESCRIPTION
Во время работы над добавлением PostgreSQL (#29), была добавлена работа с переменными окружения и конфигами.

Переменные окружения, необходимые для работы приложения, загружаются из .env-файла с помощью функции `load_environment`. Путь к файлу предоставляется через перменную `WLSS_ENV`, в которую можно предоставить значение в разных вариантах, в зависимости от сценария использования (см. доку функции `load_environment`).

Но у функции `load_environment` есть ряд недостатков, которые можно исправить рефакторингом:
1. Функция `load_environment` вызывает функцию из библиотеки `dotenv`, которая явно не объявлена у нас в зависимостях. Это было возможно только потому, что библиотка `dotenv` является транзитивной зависимостью к библиотеке `pydantic`, которая у нас установлена. Исправить это можно, если использовать возможности пайдентика, по загрузке переменных окружения из файла, а именно опцию `env_file` в классе конфига. Таким образом наша функция по работе с `WLSS_ENV` не должна сама загружать переменные окружения, а должна лишь возвращать правильный путь до .env-файла, полученный из `WLSS_ENV`.
2. Порядок разрешения путей указан в докстринге, но плохо отражен в коде:
   ```python
    envs_relative_path = PROJECT_ROOT / "envs" / WLSS_ENV
    root_relative_path = PROJECT_ROOT / WLSS_ENV
    dotenv_path = envs_relative_path if envs_relative_path.exists() else root_relative_path

    if dotenv_path.is_dir():
        dotenv_path = dotenv_path / ".env"
   ```
   Наш процесс разрешения путей, можно более явно выразить в коде если перечислить все возможные пути, которые мы пробуем разрешить, в каком-либо массиве, и после этого циклом пройтись по этому массиву и попытаться зарезолвить каждый из путей.
3. Отсутствие подробной информации о путях, которые мы проверили при поиске директории с .env-файлом в случае ошибки, если такой файл по итогу не был найден. На данный момент ошибка возникающая в этом случае это просто список ошибок пайдентика, который говорит, что переменные из конфига не заполнены.
4. Отсутствие возможности указать абсолютный путь до .env-файла вне директории проекта.

Также хотелось бы заменить исключение `InvalidEnvironment` на обычный `assert`, т.к. эта ошибка никогда не будет ловиться программно, и нет смысла хранить отдельный класс эксепшена.

В рамках этой задачи необходимо провести рефакторинг функции работающей с `WLSS_ENV`, чтобы решить перечисленные выше проблемы.