### PR TITLE
Добавить needs в cleanup воркфлоу (#127)

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -67,6 +67,7 @@ jobs:
 
   previous-runs:
     # This job is used to remove old runs of cleanup workflow itself.
+    needs: [cleanup-on-delete, cleanup-on-force-push]
 
     # we don't want to remove failed runs of cleanup workflow to make their troubleshooting possible
     if: ${{ needs.cleanup-on-delete.result != 'failure' && needs.cleanup-on-force-push.result != 'failure' }}


### PR DESCRIPTION
При добавлении удаления ранов в cleanup воркфлоу в CI (#121), мы добавили джобу `previous-runs`, которая должна удалять все предыдущие раны этого воркфлоу - т.е. раны джоб`cleanup-on-delete`, `cleanup-on-force-push` и старые раны джобы `previous-runs`. Мы планировали, чтобы джоба `previous-runs` запускалась после того как `cleanup-on-delete` и `cleanup-on-force-push` отработают, но забыли указать необходимый для этого параметр:
```yml
needs: [cleanup-on-delete, cleanup-on-force-push]
```
Без этого параметра все три джобы вызываются одновременно, и может произойти такая ситуация, при которой `previous-runs` отработает **до того** как закончат выполняться `cleanup-on-delete` и `cleanup-on-force-push`. Таким образом получится, что какая-то из этих джоб будет отменена джобой `previous-runs`, а следовательно - не будет выполнена. Т.е., например, после удаления какой-либо ветки, джоба `cleanup-on-delete` может быть отменена джобой `previous-runs`, и соответствено раны для удаляемой ветки не будут вычищены. Очистятся только раны самого cleanup воркфлоу.

В рамках этой задачи необходимо добавить пропущенный параметр `needs`, чтобы в будущем избежать возникновения описанных выше багов.