### PR TITLE
(Неактуальный) Добавить сваггер для эндпойнтов файла (#108)

### DIFF
--- a/src/file/__init__.py
+++ b/src/file/__init__.py
@@ -1,0 +1,3 @@
+"""Package for file related functionality."""
+
+from __future__ import annotations

--- a/src/file/routes.py
+++ b/src/file/routes.py
@@ -1,0 +1,66 @@
+"""File related endpoints."""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path, status, UploadFile
+from fastapi.responses import StreamingResponse
+from fastapi.security import HTTPAuthorizationCredentials
+
+from src.auth import swagger as auth_swagger
+from src.auth.security import get_token
+from src.file import schemas
+from src.shared import swagger as shared_swagger
+
+
+router = APIRouter(tags=["file"])
+
+
+@router.post(
+    "/files",
+    description="Upload new file.",
+    responses={
+        status.HTTP_200_OK: {
+            "description": "File uploaded, file info returned.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "id": "47b3d7a9-d7d3-459a-aac1-155997775a0e",
+                    },
+                },
+            },
+        },
+        status.HTTP_401_UNAUTHORIZED: auth_swagger.responses[status.HTTP_401_UNAUTHORIZED],
+        status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
+        status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
+    },
+    response_model=schemas.File,
+    status_code=status.HTTP_201_CREATED,
+    summary="Upload file.",
+)
+async def create_file(
+    new_file: UploadFile,  # noqa: ARG001
+    access_token: Annotated[HTTPAuthorizationCredentials, Depends(get_token)],  # noqa: ARG001
+) -> None:
+    """Create file."""
+
+
+@router.get(
+    "/files/{file_id}",
+    description="Get uploaded file.",
+    responses={
+        status.HTTP_200_OK: {
+            "description": "Uploaded file returned.",
+        },
+    },
+    response_class=StreamingResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get file.",
+)
+def get_file(
+    file_id: Annotated[UUID, Path(example="47b3d7a9-d7d3-459a-aac1-155997775a0e")],  # noqa: ARG001
+    access_token: Annotated[HTTPAuthorizationCredentials, Depends(get_token)],  # noqa: ARG001
+) -> None:
+    """Get file."""

--- a/src/file/schemas.py
+++ b/src/file/schemas.py
@@ -1,0 +1,13 @@
+"""Schemas for file related functionality."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from src.shared.schemas import Schema
+
+
+class File(Schema):
+    """File schema."""
+
+    id: UUID  # noqa: A003

--- a/src/routes.py
+++ b/src/routes.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter
 
 import src.account.routes
 import src.auth.routes
+import src.file.routes
 import src.friendship.routes
 import src.health.routes
 import src.profile.routes
@@ -15,6 +16,7 @@ router = APIRouter()
 
 router.include_router(src.account.routes.router)
 router.include_router(src.auth.routes.router)
+router.include_router(src.file.routes.router)
 router.include_router(src.friendship.routes.router)
 router.include_router(src.health.routes.router)
 router.include_router(src.profile.routes.router)


### PR DESCRIPTION
После добавления сваггера для эндпойнтов авторизации (#77), необходимо добавить сваггер для эндпойнтов работающих с файлами. Это необходимо для работы с аватараками пользователей.

В рамках этой задачи необходимо разработать архитектуру и добавить сваггер для эндпойнтов, работающих с файлами.