### PR TITLE
Поправить применение миграций для тестов на CI (#130)

### DIFF
--- a/envs/ci/test/docker-compose.yml
+++ b/envs/ci/test/docker-compose.yml
@@ -24,7 +24,11 @@ services:
     volumes:
       # bind .pytest_cache to the host in order to store pytest cache in GitHub Cache
       - ../../../.pytest_cache:/wlss-backend/.pytest_cache  # host path is relative to the current docker-compose file
-    entrypoint: pytest --cov=src
+    entrypoint: |
+      bash -c "
+        alembic upgrade head
+        pytest --cov=src
+      "
 
   postgres:
     image: postgres:latest


### PR DESCRIPTION
Во время работы над вынесением функциональности из `pytest_sessionstart` (#119), мы убрали автоматическое применение миграций перед началом тестовой сессии, но при этом не учли, что в таком случае нам необходимо явно прописать применение миграций во время запуска на CI.

В рамках этой задачи необходимо добавить команду применения миграций перед запуском тестов на CI.