### PR TITLE
Вынести pull докер образов на CI в отдельный шаг (#132)

### DIFF
--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -21,8 +21,11 @@ jobs:
       - name: Create .env file
         run: source envs/ci/db/env.sh
 
-      - name: Build alembic
+      - name: Build images
         run: docker compose --file envs/ci/db/docker-compose.yml build
+
+      - name: Pull images
+        run: docker compose --file envs/ci/db/docker-compose.yml pull --ignore-buildable
 
       - name: Run alembic
         run: docker compose --file envs/ci/db/docker-compose.yml up --attach alembic --exit-code-from alembic

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,11 @@ jobs:
       - name: Create .env file
         run: source envs/ci/test/env.sh
 
-      - name: Build pytest
+      - name: Build images
         run: docker compose --file envs/ci/test/docker-compose.yml build
+
+      - name: Pull images
+        run: docker compose --file envs/ci/test/docker-compose.yml pull --ignore-buildable
 
       - name: Run pytest
         run: docker compose --file envs/ci/test/docker-compose.yml up --attach pytest --exit-code-from pytest


### PR DESCRIPTION
На данный момент, у нас в CI есть несколько воркфлоу, которые требуют больше одного контейнера для запуска - например `test.yml` запускает базу данных в одном контейнере и пайтест в другом.

Во время работы над задачей добавления юнит-тестов в CI (#15), мы разделили билд и запуск пайтеста на два отдельных шага:
```yml
- name: Build pytest
  run: docker compose --file envs/ci/docker-compose.yml build pytest

- name: Run pytest
  run: docker compose --file envs/ci/docker-compose.yml run pytest
```
Это было сделано для того, чтобы аутпут лог самого пайтеста, содержащий полезную информацию, не засорялся билд логами докера, чтобы пользователь, который захочет посмотреть как отработал пайтест, сразу мог зайти в шаг "Run pytest" и увидеть там логи самого пайтеста.

Но при этом во время работы на задачей добавления PostgreSQL (#29), нам пришлось добавить так же контейнер с постгресом, и это привело к тому что шаг "Run pytest" стал содержать логи пуллинга образа постгреса, и таким образом засорять лог пайтеста.

Исправить это можно если вынести пуллинг образов докера в отдельный шаг, т.е. будет что-то вроде такого:
```yml
- name: Build images
  run: docker compose ... build

- name: Pull images
  run: docker compose ... pull

- name: Run containers
  run: docker compose ... up
```

Аналогичная проблема существует и в воркфлоу `db.yml`, который запускает алембик для проверки миграции базы данных.

В рамках этой задачи необходимо вынести пуллинг докер образов в отдельный шаг для вокрфлоу алембика и пайтеста, чтобы логи самих тулов не были засорены логами докера.