### PR TITLE
Зафиксировать версии внешних сервисов (#136)

### DIFF
--- a/envs/ci/db/docker-compose.yml
+++ b/envs/ci/db/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       "
 
   postgres:
-    image: postgres:latest
+    image: postgres:16.0-alpine
     env_file:
       - .env
     healthcheck:

--- a/envs/ci/test/docker-compose.yml
+++ b/envs/ci/test/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       "
 
   postgres:
-    image: postgres:latest
+    image: postgres:16.0-alpine
     env_file:
       - .env
     healthcheck:
@@ -43,7 +43,7 @@ services:
       - postgres:/var/lib/postgresql/data
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2023-10-25T06-33-25Z
     env_file:
       - .env
     healthcheck:

--- a/envs/local/dev/docker-compose.yml
+++ b/envs/local/dev/docker-compose.yml
@@ -4,7 +4,7 @@ name: wlss-local-dev
 
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:16.0-alpine
     env_file:
       - .env
     ports:
@@ -13,7 +13,7 @@ services:
       - postgres:/var/lib/postgresql/data
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2023-10-25T06-33-25Z
     env_file:
       - .env
     ports:

--- a/envs/local/test/docker-compose.yml
+++ b/envs/local/test/docker-compose.yml
@@ -4,7 +4,7 @@ name: wlss-local-test
 
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:16.0-alpine
     env_file:
       - .env
     ports:
@@ -13,7 +13,7 @@ services:
       - postgres:/var/lib/postgresql/data
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2023-10-25T06-33-25Z
     env_file:
       - .env
     ports:

--- a/envs/test/docker-compose.yml
+++ b/envs/test/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       "
 
   postgres:
-    image: postgres:latest
+    image: postgres:16.0-alpine
     env_file:
       - .env
     healthcheck:
@@ -35,7 +35,7 @@ services:
       - postgres:/var/lib/postgresql/data
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2023-10-25T06-33-25Z
     env_file:
       - .env
     healthcheck:


### PR DESCRIPTION
На данный момент внешние зависимости проекта, а именно postgres и minio, в докер-компоуз файлах имеют последную версию - latest. Это может вызывать ряд определённых проблем, когда версия постгреса или минио обновится, она может оказаться не совместима с текущим проектом.

Такая проблема произошла с minio - после нового релиза минио наш healthcheck перестал работать, и следовательно, контейнеры перестали работать с минио. При этом в коде нашего приложения ничего не менялось, т.е. приложение перестало работать только из-за того, что в последней сборке подтянулась новая версия минио, которая судя по всему не совместима с нашим healthcheck-ом.

Чтобы предотвратить такие ситуации в дальнейшем и всегда иметь предсказуемую сборку, в рамках этой задачи необходимо зафиксировать конкретные версии внешних зависимостей, которые мы используем в проекте.