### PR TITLE
Добавить сваггер для эндпойнтов файла (#108)

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -16,3 +16,8 @@ strict = True
 [mypy-minio.*]
 
 ignore_missing_imports = True
+
+
+[mypy-varname.*]
+
+ignore_missing_imports = True

--- a/poetry.lock
+++ b/poetry.lock
@@ -422,6 +422,21 @@ dnspython = ">=1.15.0"
 idna = ">=2.0.0"
 
 [[package]]
+name = "executing"
+version = "2.0.1"
+description = "Get the currently executing AST node of a frame, and other information"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "executing-2.0.1-py2.py3-none-any.whl", hash = "sha256:eac49ca94516ccc753f9fb5ce82603156e590b27525a8bc32cce8ae302eb61bc"},
+    {file = "executing-2.0.1.tar.gz", hash = "sha256:35afe2ce3affba8ee97f2d69927fa823b08b472b7b994e36a52a964b93d16147"},
+]
+
+[package.extras]
+tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipython", "littleutils", "pytest", "rich"]
+
+[[package]]
 name = "fastapi"
 version = "0.95.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -2138,6 +2153,24 @@ docs = ["Sphinx (>=4.1.2,<4.2.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)", "sphinxc
 test = ["Cython (>=0.29.32,<0.30.0)", "aiohttp", "flake8 (>=3.9.2,<3.10.0)", "mypy (>=0.800)", "psutil", "pyOpenSSL (>=22.0.0,<22.1.0)", "pycodestyle (>=2.7.0,<2.8.0)"]
 
 [[package]]
+name = "varname"
+version = "0.12.0"
+description = "Dark magics about variable names in python."
+category = "dev"
+optional = false
+python-versions = ">=3.8,<4.0"
+files = [
+    {file = "varname-0.12.0-py3-none-any.whl", hash = "sha256:fc0d056072918efc76375237cbbaa49402f22cc06ed61e893ac71c272d3b3f4d"},
+    {file = "varname-0.12.0.tar.gz", hash = "sha256:ca0c7c974a1a9382144eeee21ab429286c9de8259248ce40a9f48bcf08adb223"},
+]
+
+[package.dependencies]
+executing = ">=2.0,<3.0"
+
+[package.extras]
+all = ["asttokens (>=2.0.0,<3.0.0)", "pure_eval (<1.0.0)"]
+
+[[package]]
 name = "watchfiles"
 version = "0.19.0"
 description = "Simple, modern and high performance file watching and code reload in python."
@@ -2340,4 +2373,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "b418970051fa1b72b8a5db17449844985a5e14b3f526dc02b151cbc5f9c5fa28"
+content-hash = "3b1dfd61339a1dcf3fafa5436a237b41bca1f8b45912b5e9033553332bb5a1b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ overrides = "7.3.1"
 psycopg2-binary = "2.9.7"  # used for some special cases when we cannot work with database via async code
 python-dotenv = "1.0.0"
 sqlalchemy = {extras = ["asyncio"], version = "2.0.12"}
+varname = "0.12.0"
 
 
 [tool.poetry.group.lint]

--- a/src/file/__init__.py
+++ b/src/file/__init__.py
@@ -1,0 +1,3 @@
+"""Package for file related functionality."""
+
+from __future__ import annotations

--- a/src/file/constants.py
+++ b/src/file/constants.py
@@ -1,0 +1,14 @@
+"""Constants related to file."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from typing import Final
+
+
+BYTE: Final = 1
+KILOBYTE: Final = 1024 * BYTE
+MEGABYTE: Final = 1024 * KILOBYTE

--- a/src/file/enums.py
+++ b/src/file/enums.py
@@ -1,0 +1,60 @@
+"""Enumerations for file functionality."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from varname import nameof
+
+from src.shared.enum import Enum, types
+
+
+if TYPE_CHECKING:
+    from typing import Self
+
+
+@types(str)
+class Extension(Enum):
+    """Enum for available file extensions."""
+
+    GIF = "gif"
+    JFIF = "jfif"
+    JIF = "jif"
+    JPE = "jpe"
+    JPEG = "jpeg"
+    JPG = "jpg"
+    PNG = "png"
+    WEBP = "webp"
+
+    @property
+    def mime_type(self: Self) -> MimeType:  # pragma: no cover
+        """Get associated mime-type."""
+        return _extension_mime_type[self]
+
+
+class MimeType(Enum):
+    """Enum for available mime-types."""
+
+    IMAGE_GIF = "image/gif"
+    IMAGE_JPEG = "image/jpeg"
+    IMAGE_PNG = "image/png"
+    IMAGE_WEBP = "image/webp"
+
+
+_extension_mime_type = {
+    Extension.GIF: MimeType.IMAGE_GIF,
+    Extension.JFIF: MimeType.IMAGE_JPEG,
+    Extension.JIF: MimeType.IMAGE_JPEG,
+    Extension.JPE: MimeType.IMAGE_JPEG,
+    Extension.JPEG: MimeType.IMAGE_JPEG,
+    Extension.JPG: MimeType.IMAGE_JPEG,
+    Extension.PNG: MimeType.IMAGE_PNG,
+    Extension.WEBP: MimeType.IMAGE_WEBP,
+}
+
+
+assert set(Extension) == set(_extension_mime_type), (
+    # pylint: disable-next=consider-using-f-string
+    "Each `{Extension}` enum member should have according mime-type registered in `{_extension_mime_type}` dict."
+    .format(Extension=nameof(Extension), _extension_mime_type=nameof(_extension_mime_type))
+)

--- a/src/file/fields.py
+++ b/src/file/fields.py
@@ -1,0 +1,22 @@
+"""Field definitions for Pydantic models."""
+
+from __future__ import annotations
+
+from src.file.constants import BYTE, MEGABYTE
+from src.shared.fields import IntField, StrField
+
+
+class Size(IntField):
+    """File size value field."""
+
+    FIELD_NAME = "File size in bytes"
+    VALUE_MAX = 10 * MEGABYTE
+    VALUE_MIN = 1 * BYTE
+
+
+class Name(StrField):
+    """File name value field."""
+
+    FIELD_NAME = "File name"
+    LENGTH_MAX = 255
+    LENGTH_MIN = 1

--- a/src/file/routes.py
+++ b/src/file/routes.py
@@ -1,0 +1,67 @@
+"""File related endpoints."""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Path, status, UploadFile
+from fastapi.responses import FileResponse
+from fastapi.security import HTTPAuthorizationCredentials
+
+from src.auth.security import get_token
+from src.file import schemas
+from src.shared import swagger as shared_swagger
+
+
+router = APIRouter(tags=["file"])
+
+
+@router.post(
+    "/files",
+    description="Upload new file.",
+    responses={
+        status.HTTP_200_OK: {
+            "description": "File uploaded, file info returned.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "id": "47b3d7a9-d7d3-459a-aac1-155997775a0e",
+                    },
+                },
+            },
+        },
+        status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
+        status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
+    },
+    response_model=schemas.File,
+    status_code=status.HTTP_201_CREATED,
+    summary="Upload file.",
+)
+async def create_file(
+    new_file: UploadFile,  # noqa: ARG001
+    access_token: Annotated[HTTPAuthorizationCredentials, Depends(get_token)],  # noqa: ARG001
+) -> None:
+    """Create file."""
+
+
+@router.get(
+    "/files/{file_id}",
+    description="Get (download) uploaded file.",
+    responses={
+        status.HTTP_200_OK: {
+            "description": "Uploaded file returned.",
+        },
+        status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
+        status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
+        status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
+    },
+    response_class=FileResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get file.",
+)
+async def get_file(
+    file_id: Annotated[UUID, Path(example="47b3d7a9-d7d3-459a-aac1-155997775a0e")],  # noqa: ARG001
+    access_token: Annotated[HTTPAuthorizationCredentials, Depends(get_token)],  # noqa: ARG001
+) -> None:
+    """Get file."""

--- a/src/file/schemas.py
+++ b/src/file/schemas.py
@@ -1,0 +1,20 @@
+"""Schemas for file related functionality."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from src.file.enums import Extension, MimeType
+from src.file.fields import Name, Size
+from src.shared.schemas import Schema
+
+
+class File(Schema):
+    """File schema."""
+
+    id: UUID  # noqa: A003
+
+    extension: Extension
+    mime_type: MimeType
+    name: Name
+    size: Size

--- a/src/routes.py
+++ b/src/routes.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter
 
 import src.account.routes
 import src.auth.routes
+import src.file.routes
 import src.friendship.routes
 import src.health.routes
 import src.profile.routes
@@ -16,6 +17,7 @@ router = APIRouter()
 
 router.include_router(src.account.routes.router)
 router.include_router(src.auth.routes.router)
+router.include_router(src.file.routes.router)
 router.include_router(src.friendship.routes.router)
 router.include_router(src.health.routes.router)
 router.include_router(src.profile.routes.router)

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -64,6 +64,18 @@ fget
 # full match (used by `re` library)
 fullmatch
 
+# jfif - image format
+jfif
+
+# jif - image format
+jif
+
+# jpe - image format
+jpe
+
+# jpg - image format
+jpg
+
 # generate salt
 gensalt
 
@@ -90,6 +102,9 @@ minioadmin
 
 # MyPy - static type checker for python (pylint spellcheck)
 mypy
+
+# name of (function from `varname` package)
+nameof
 
 # sqlalchemy column property nullable
 nullable
@@ -162,8 +177,14 @@ validator
 # validators
 validators
 
+# variable name (`varname` python package)
+varname
+
 # unit-test (python library)
 unittest
+
+# webp - image format
+webp
 
 # whitespaces
 whitespaces


### PR DESCRIPTION
После добавления сваггера для эндпойнтов авторизации (#77), необходимо добавить сваггер для эндпойнтов работающих с файлами. Это необходимо для работы с аватараками пользователей.

В рамках этой задачи необходимо разработать архитектуру и добавить сваггер для эндпойнтов, работающих с файлами.

---

В процессе реализации были приняты следующие решения:

Кроме uuid фала, мы также решили сохранять в бд дополнительные сведения о загружаемых файлах, а именно:

- `name` - полное имя файла, например `"john_doe.png"`
- `size` - размер файла в байтах, например `1_048_576`
- `extension` - разрешение файла, например `"png"`
- `mime_type` - MIME-тип данных, например `"image/png"`

Именно поэтому мы добавили эту информацию в респонз эндпойнта на загрузку нового файла.

Возможно, в будущем эта информация окажется нам не нужна, и мы удалим её из бд, но на данный момент было принято решение добавить её, т.к. если её не будет в бд и в какой-то момент мы поймём, что она всё-таки нам нужна, то её будет довольно трудно восстановить - придётся проводить миграцию, в которой нужно будет брать все файлы из minio и вычислять эти параметры для каждого файла, чтобы записать их в бд для уже существующих фалов.

Также было принято решение не добавлять каких-либо ограничений для имен файлов, по следующим причинам:

1. Ограничения для допустимых имён файлов отличаются на разных системах, и чтобы учесть их все, необходимо проделать значительную работу.

2. Мы предполагаем, что пользователь загружает файл из операционной системы, и поскольку файл существует в его операционной системе, значит имя этого файла не нарушает правил этой операционной системы. Следовательно, предполагаем, что если пользователь смог загрузить файл, то он сможет его и скачать с тем же имененм.