### PR TITLE
Поправить прокидывание .env-файла на QA стенде (#144)

### DIFF
--- a/envs/qa/docker-compose.yml
+++ b/envs/qa/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     build:
       context: ../..  # path from the corrent file to the project root dir
       dockerfile: envs/qa/Dockerfile  # path from the project root dir to the Dockerfile
-    env_file:
-      - .env
     environment:
       - WLSS_ENV=qa
     depends_on:
@@ -16,6 +14,8 @@ services:
         condition: service_healthy
       minio:
         condition: service_healthy
+    volumes:
+      - .env:/wlss-backend/envs/qa/.env
     entrypoint: >
       bash -c "
         alembic upgrade head


### PR DESCRIPTION
Во время работы над добавлением CD (#51) для нашего приложения, разворачивающегося на стенде, была добавлена конфигурация докера, в которой (по соображениям безопасности) из сборки был исключен `.env` файл (см. соответствующий `Dockerfile.dockerignore`). Но при этом мы не учли, что этот .env-файл требуется нашему приложению для работы - приложение запускается в окружении, в котором определена переменная `WLSS_ENV`, которая указывает на тот .env-файл, из которого приложению необходимо загрузить переменные окружения (с помощью функции `load_environment()`).

Т.е. приложение функционировало не так, как мы ожидали, но при этом не выдавало никаких ошибок, потому что:

1. В docker-compose файле в секции `env:` была указан путь до `.env` файла. Т.е. докер-компоуз самостоятельно загружал переменные окружения из файла `.env` в контейнер, в котором запускалось приложение. Поэтому мы не видели ошибок о пропущенных опциях конфигурации от приложения.

2. Наша функция `load_environment()` для загрузки переменных окружения из файла использовала функцию `load_dotenv()` из библиотеки `python-dotenv`, и как оказалось, эта функция не поднимает исключения, если её пытаются вызвать передав ей путь до несуществующего файла, она просто возвращает `False`. Поэтому мы не видели никаких ошибок от функции загрузки переменных окружения из .env-файла (`load_environment()`).

Во время рефакторинга функции работающей с `WLSS_ENV` (#122), мы сделали так, чтобы эта функция поднимала исключение, если необходимый .env-файл не был найден, и это привело к тому, что наш контейнер с приложением перестал работать, т.к. `.env` файл не прокидывался в контейнер и как следствие не мог быть найден нашей функцией `get_dotenv_path()`.

Чтобы поправить этот баг, необходимо добавить прокидывание `.env` файла в контейнер приложения через докер volume, а также убрать ненужную секцию `env:`.

В рамках этой задачи необходимо поправить прокидывание .env-файла на QA стенде.