### PR TITLE
Расширить использование dirty_equals (#149)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -661,21 +661,6 @@ files = [
 flake8 = ">3.0.0"
 
 [[package]]
-name = "freezegun"
-version = "1.2.2"
-description = "Let your Python tests travel through time"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "freezegun-1.2.2-py3-none-any.whl", hash = "sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f"},
-    {file = "freezegun-1.2.2.tar.gz", hash = "sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446"},
-]
-
-[package.dependencies]
-python-dateutil = ">=2.7"
-
-[[package]]
 name = "greenlet"
 version = "2.0.2"
 description = "Lightweight in-process concurrent programming"
@@ -2373,4 +2358,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "3b1dfd61339a1dcf3fafa5436a237b41bca1f8b45912b5e9033553332bb5a1b0"
+content-hash = "cb21ba99282338ad3c08cd8a6bf6fe8b8e48313326682ef1b0a139c88bee6c5f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ optional = true
 [tool.poetry.group.test.dependencies]
 
 dirty-equals = "0.6.0"
-freezegun = "1.2.2"
 pytest = "7.3.0"
 pytest-cov = "4.0.0"
 pytest-env = "0.8.1"  # needed to set up default $WLSS_ENV for tests execution

--- a/src/shared/datetime.py
+++ b/src/shared/datetime.py
@@ -3,6 +3,14 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from typing import Final
+
+
+DATETIME_FORMAT: Final = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
 def utcnow() -> datetime:
@@ -10,15 +18,10 @@ def utcnow() -> datetime:
 
     There are two reasons of having this function instead of just using `datetime.now(tz=timezone.utc)` everywhere:
 
-        1. We're using `freezgun` library which cannot mock datetime in sqlalchemy's column definitions, like:
-        ```python
-        created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
-        ```
-        because class level attributes are evaluated at compile time. This happens before `freezegun`
-        has patched datetime.datetime.now, so the column default functions still point to the stdlib implementation.
-        See this SO answer for details: https://stackoverflow.com/a/58776798/8431075
+        1. We have to provide a callable to sqlalchemy column definition which should return timezone-aware datetime.
 
-        That's why we should wrap datetime.utcnow to another function.
+           It means that we can not provide just `default=datetime.now` because it is not using UTC timezone.
+           We also can not use `default=datetime.utcnow` because it returns timezone-naive datetime object.
 
         2. Simply `utcnow()` is shorter than `datetime.now(tz=timezone.utc)`
 

--- a/src/shared/schemas.py
+++ b/src/shared/schemas.py
@@ -6,6 +6,8 @@ from datetime import datetime
 
 from pydantic import BaseModel
 
+from src.shared.datetime import DATETIME_FORMAT
+
 
 class Schema(BaseModel):
     """Customized 'BaseModel' class from pydantic."""
@@ -13,7 +15,7 @@ class Schema(BaseModel):
     class Config:
         """Pydantic's special class to configure pydantic models."""
 
-        json_encoders = {datetime: lambda v: v.strftime("%Y-%m-%dT%H:%M:%S.%fZ")}
+        json_encoders = {datetime: lambda v: v.strftime(DATETIME_FORMAT)}
 
 
 class HTTPError(Schema):

--- a/tests/test_auth/test_create_account.py
+++ b/tests/test_auth/test_create_account.py
@@ -1,50 +1,47 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from unittest.mock import patch
 
 import bcrypt
-import dirty_equals
 import pytest
-from freezegun import freeze_time
 from sqlalchemy import select
 
 from src.account.models import Account, PasswordHash
 from src.profile.models import Profile
 from src.shared.database import Base
+from src.shared.datetime import utcnow
+from tests.utils.dirty_equals import PositiveInt, UtcDatetime, UtcDatetimeStr
 from tests.utils.mocks.models import __eq__
 
 
 @pytest.mark.anyio
 @pytest.mark.fixtures({"client": "client", "db": "db_empty"})
 async def test_create_account_returns_201_with_correct_body(f):
-    with freeze_time("2023-10-30T20:00:00.000000"):
-
-        result = await f.client.post(
-            "/accounts",
-            json={
-                "account": {
-                    "email": "john.doe@mail.com",
-                    "login": "john_doe",
-                    "password": "qwerty123",
-                },
-                "profile": {
-                    "name": "John Doe",
-                    "description": "I'm the best guy for your mocks.",
-                },
+    result = await f.client.post(
+        "/accounts",
+        json={
+            "account": {
+                "email": "john.doe@mail.com",
+                "login": "john_doe",
+                "password": "qwerty123",
             },
-        )
+            "profile": {
+                "name": "John Doe",
+                "description": "I'm the best guy for your mocks.",
+            },
+        },
+    )
 
     assert result.status_code == 201
     assert result.json() == {
         "account": {
-            "id": dirty_equals.IsPositiveInt,
-            "created_at": "2023-10-30T20:00:00.000000Z",
+            "id": PositiveInt(like=42),
+            "created_at": UtcDatetimeStr(like="2023-06-17T11:47:02.823Z"),
             "email": "john.doe@mail.com",
             "login": "john_doe",
         },
         "profile": {
-            "account_id": dirty_equals.IsPositiveInt,
+            "account_id": PositiveInt(like=42),
             "avatar_id": None,
             "description": "I'm the best guy for your mocks.",
             "name": "John Doe",
@@ -56,7 +53,6 @@ async def test_create_account_returns_201_with_correct_body(f):
 @pytest.mark.fixtures({"client": "client", "db": "db_empty"})
 async def test_create_account_creates_objects_in_db_correctly(f):
     with (
-        freeze_time("2023-10-30T20:00:00.000000"),
         patch.object(bcrypt, "hashpw", lambda *_: b"password-hash"),
     ):
 
@@ -79,28 +75,28 @@ async def test_create_account_creates_objects_in_db_correctly(f):
         accounts = (await f.db.execute(select(Account))).scalars().all()
         assert accounts == [
             Account(
-                created_at=datetime(2023, 10, 30, 20, 0, tzinfo=timezone.utc),
+                created_at=UtcDatetime(like=utcnow()),
                 email="john.doe@mail.com",
-                id=dirty_equals.IsPositiveInt,
+                id=PositiveInt(like=42),
                 login="john_doe",
-                updated_at=datetime(2023, 10, 30, 20, 0, tzinfo=timezone.utc),
+                updated_at=UtcDatetime(like=utcnow()),
             ),
         ]
         profiles = (await f.db.execute(select(Profile))).scalars().all()
         assert profiles == [
             Profile(
-                account_id=dirty_equals.IsPositiveInt,
+                account_id=PositiveInt(like=42),
                 avatar_id=None,
                 description="I'm the best guy for your mocks.",
                 name="John Doe",
-                updated_at=datetime(2023, 10, 30, 20, 0, tzinfo=timezone.utc),
+                updated_at=UtcDatetime(like=utcnow()),
             ),
         ]
         password_hashes = (await f.db.execute(select(PasswordHash))).scalars().all()
         assert password_hashes == [
             PasswordHash(
-                account_id=dirty_equals.IsPositiveInt,
-                updated_at=datetime(2023, 10, 30, 20, 0, tzinfo=timezone.utc),
+                account_id=PositiveInt(like=42),
+                updated_at=UtcDatetime(like=utcnow()),
                 value=b"password-hash",
             ),
         ]

--- a/tests/utils/dirty_equals.py
+++ b/tests/utils/dirty_equals.py
@@ -1,0 +1,106 @@
+"""Customized dirty_equals classes useful for testing.
+
+Most of them have rigid structure suitable for our application only.
+Since they serve only for testing convenience we didn't want
+to make them flexible and extensible. We just "hard-coded" all
+things we wanted them to check in tests for our application.
+"""
+
+from __future__ import annotations
+
+from datetime import timezone
+from typing import TYPE_CHECKING
+
+import dirty_equals
+
+from src.shared.datetime import DATETIME_FORMAT
+
+
+if TYPE_CHECKING:
+    from datetime import datetime
+    from typing import Any, Self
+
+
+class PositiveInt(dirty_equals.IsPositiveInt):
+    """Customized dirty_equals.IsPositive."""
+
+    def __init__(self: Self, *, like: int | None = None) -> None:
+        """Initialize object.
+
+        :param like: example value (required)
+
+        :raises AssertionError: `like` value is not correct
+        """
+        assert like is not None, "Provide correct example value in `like` argument."
+
+        self._like = like
+        super().__init__()
+
+        try:
+            like_equals = self.equals(self._like)
+
+        except TypeError:
+            msg = f"`like` argument has type {type(self._like)}, but expected {self.allowed_types}."
+            raise AssertionError(msg) from None
+
+        assert like_equals, "Example value from `like` argument is not correct."
+
+
+class UtcDatetime(dirty_equals.IsDatetime):
+    """Customized dirty_equals.IsDatetime to change timezone-aware datetime objects with UTC timezone."""
+
+    def __init__(self: Self, *, like: datetime | None = None) -> None:
+        """Initialize object.
+
+        :param like: example value (required)
+
+        :raises AssertionError: `like` value is not correct
+        """
+        assert like is not None, "Provide correct example value in `like` argument."
+
+        self._like = like
+        super().__init__(iso_string=False)
+
+        try:
+            like_equals = self.equals(self._like)
+
+        except TypeError:
+            msg = f"`like` argument has type {type(self._like)}, but expected {self.allowed_types}."
+            raise AssertionError(msg) from None
+
+        assert like_equals, "Example value from `like` argument is not correct."
+
+    def equals(self: Self, other: Any) -> bool:  # noqa: ANN401
+        """Return True if `self` "dirty equals" to `other` or False otherwise."""
+        return super().equals(other) and other.tzinfo == timezone.utc
+
+
+class UtcDatetimeStr(dirty_equals.IsDatetime):
+    """Customized dirty_equals.IsDatetime to check timezone-aware ISO formatted datetime strings with UTC timezone."""
+
+    expected_format = DATETIME_FORMAT
+
+    def __init__(self: Self, *, like: str | None = None) -> None:
+        """Initialize object.
+
+        :param like: example value (required)
+
+        :raises AssertionError: `like` value is not correct
+        """
+        assert like is not None, "Provide correct example value in `like` argument."
+
+        self._like = like
+        super().__init__(format_string=self.expected_format)
+
+        try:
+            like_equals = self.equals(self._like)
+
+        except TypeError:
+            msg = f"`like` argument has type {type(self._like)}, but expected {self.allowed_types}."
+            raise AssertionError(msg) from None
+
+        except ValueError:
+            msg = f"`like` argument '{self._like}' does not match expected format '{self.expected_format}'."
+            raise AssertionError(msg) from None
+
+        assert like_equals, "Example value from `like` argument is not correct."


### PR DESCRIPTION
Во время работы над реализацией эндпойнта регистрации (#88), было принято решение использовать библиотеку [freezegun](https://github.com/spulec/freezegun#freezegun-let-your-python-tests-travel-through-time), для поверок данных с динамически генерируемыми датами в тестах. Планировалось в тестах "замораживать" время используя определённую константу, и затем использовать эту константу в проверках.

Но в дальнейшем при попытке реализовать эндпойнты файла (#148), выяснилось, что если в тесте мы замораживаем время, а потом посылаем запрос в minio, то сервер minio отклоняет такой запрос с ошибкой, говорящей, что время запроса слишком сильно отличается от времени установленном на сервере.

Чтобы решить эту проблему, мы можем использовать библиотеку [dirty_equals](https://dirty-equals.helpmanual.io/latest/) вместо freezegun для проверки динамически генерируемых значений даты и времени в тестах.

Так же хотелось бы решить одну небольшую проблему возникающую при использовании dirty_equals - сокрытие примеров значений в ассертах. Например, в таком ассерте визуально не понятно, какое значение (хотя бы примерно) будет в колонке id:
```python
assert response.json() == {
    "id": IsPositiveInt(),
    "name": "John Doe",
}
```

Для этого было принято решение слегка модифицировать классы библиотеки dirty_equals и добавить им возможность указать пример значение через аргумент `like`, т.е.:
```python
assert response.json() == {
    "id": PositiveInt(like=42),
    "name": "John Doe",
}
```

При этом значение указанное в аргументе `like`, так же должно проверятся на соответствие используемому классу, т.е. следующий пример должен давать ошибку:
```python
assert response.json() == {
    "id": PositiveInt(like=-1)
    "name": "John Doe",
}
```

В рамках этой задачи необходимо настроить и использовать dirty_equals для проверок автогенерируемых значений.