### PR TITLE
Убрать ограничения длины для имён файлов (#154)

### DIFF
--- a/src/file/fields.py
+++ b/src/file/fields.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from src.file.constants import BYTE, MEGABYTE
-from src.shared.fields import IntField, StrField
+from src.shared.fields import IntField
 
 
 class Size(IntField):
@@ -12,11 +12,3 @@ class Size(IntField):
     FIELD_NAME = "File size in bytes"
     VALUE_MAX = 10 * MEGABYTE
     VALUE_MIN = 1 * BYTE
-
-
-class Name(StrField):
-    """File name value field."""
-
-    FIELD_NAME = "File name"
-    LENGTH_MAX = 255
-    LENGTH_MIN = 1

--- a/src/file/schemas.py
+++ b/src/file/schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from uuid import UUID
 
 from src.file.enums import Extension, MimeType
-from src.file.fields import Name, Size
+from src.file.fields import Size
 from src.shared.schemas import Schema
 
 
@@ -16,5 +16,4 @@ class File(Schema):
 
     extension: Extension
     mime_type: MimeType
-    name: Name
     size: Size


### PR DESCRIPTION
Было принято решение не сохранять имена загружаемых файлов в системе. После загрузки файла в систему, в качестве имени будет использоваться идентификатор файла. Когда пользователь будет скачивать файл, то имя скачиваемого файла будет чем-то вроде "e7cb57a4-18e9-4a6d-bd2b-75aff454ca27.png".

Такое решение было принято, чтобы снять с пользователя обязательство следить за именами загружаемых файлов, а также чтобы упростить часть логики кода, связанную с пересылкой файлов, на фронте и беке.

В рамках этой задачи необходимо убрать код работающий с именами файлов.