### PR TITLE
Поправить сваггер пример для эндпйонта добавления файла (#156)

### DIFF
--- a/src/file/routes.py
+++ b/src/file/routes.py
@@ -27,6 +27,9 @@ router = APIRouter(tags=["file"])
                 "application/json": {
                     "example": {
                         "id": "47b3d7a9-d7d3-459a-aac1-155997775a0e",
+                        "extension": "png",
+                        "mime_type": "image/png",
+                        "size": 2048,
                     },
                 },
             },


### PR DESCRIPTION
Во время работы над добавлением сваггера для эндпойнтов файла (#108), в сваггер для эндпойнта добавления файла был добавлен пример ответа, который не соответствует схеме ответа:
```python
"example": {
    "id": "47b3d7a9-d7d3-459a-aac1-155997775a0e",
},
```

При этом выходная схема этого эндпойнта выглядит так:
```python
class File(Schema):
    """File schema."""

    id: UUID  # noqa: A003

    extension: Extension
    mime_type: MimeType
    size: Size
```

В рамках этой задачи необходимо добавить значения для полей `extension`, `mime_type` и `size` в пример ответа в сваггере для эндпойнта добавления файла.