### PR TITLE
Исправить удаление бакетов перед запуском тестов (#162)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,6 @@ async def minio_empty():
     for _, bucket_name in minio.BUCKETS:
         for minio_object in minio.list_objects(bucket_name, recursive=True):
             minio.remove_object(bucket_name, minio_object.object_name)
-        minio.remove_bucket(bucket_name)
     return minio
 
 


### PR DESCRIPTION
Во время работы над добавлением minio (#35), в файл tests/conftest.py была добавлена фикстура, которая должна инициализировать minio перед каждым тестом. Эта инициализация должна включать в себя очистку всех данных в клиенте minio, использующемся для теста.

Дли очистки данных был добавлен следующий код:
```python
@pytest.fixture
async def minio():  # в последствии функция была переименована в minio_empty
    """Empty minio."""
    minio = next(get_minio())
    for _, bucket_name in minio.BUCKETS:
        for minio_object in minio.list_objects(bucket_name, recursive=True):
            minio.remove_object(bucket_name, minio_object.object_name)
        minio.remove_bucket(bucket_name)
    return minio
```

но у этого кода есть одна проблема - он не только очищает данные с minio, но и удаляет все бакеты.

В моменте добавления этого кода, тесты не смогли отследить эту проблему, т.к. у нас не был написан тест на получение файла из minio. Этот тест помог бы выявить проблему, т.к. в этом тесте код работал бы следующим образом:

1. Загрузка фикстуры minio_empty, которая очищает данные и бакеты в minio.
2. Загрузка дочерней фикстуры minio_with_one, которая доабвляет файл в minio после работы minio_empty
3. Запуск теста, в котором вызывается наш эндпойнт.
4. Загрузка minio через Depends самого эндпойнта, где в рамках инициализации minio вызывается `_create_missing_buckets`.
5. Отработка эндпойнта в которой получаются данные из minio.
6. Проверка ассертов в тесте
7. Отработка teardown-фаз в фикстурах.

В этом сценарии мы бы обнаружили эту ошибку на шаге 2 - при попытке добавить файл в minio после того, как бакеты были удалены фикстурой minio_empty.

Но т.к. на момент добавления этого кода и долгое время после этого для minio у нас был написан только один тест - проверка создания файла в minio - то в сценарии, который мы прогоняли в тестах, не было шага 2, и как следствие ошибка не возникала.

Эта проблема проявилась лишь в тот момент, когда мы занялись реализацией эндпойнта получения файла (#163) и написали к нему тесты.

В рамках этой задачи необходимо убрать строчку `minio.remove_bucket(bucket_name)`, т.к. очистка minio перед тестами предполагает только очистку данных из minio, но не самой структуры бакетов.

---

Для того чтобы понять, почему нам следует очищать данные из minio, но не следует удалять сами бакеты, можно провести параллель с реляционной базой данных - в тестах с участием бд, мы не хотим перед каждым тестом накатывать миграции и создавать таблицы и статические данные, т.к. эти вещи никак не будут меняться в тестах. Но при этом мы хотим вычищать сами данные (динамические), которые изменяются в тестах. По этой аналагии - бакеты в minio, это играют ту же самую роль, что и таблицы в бд, т.е. бакеты в minio можно назвать "схемой" minio по аналогии с бд. Схема не меняется во время работы тестов, меняются лишь данные, поэтому мы не хотим очищать "схему" minio перед каждым тестом, нам нужно очищать лишь сами данные.