### PR TITLE
 Добавить параметры запроса в reject_friendship_request (#167)

### DIFF
--- a/src/friendship/routes.py
+++ b/src/friendship/routes.py
@@ -193,7 +193,10 @@ async def accept_friendship_request(
     status_code=status.HTTP_200_OK,
     summary="Reject friendship request.",
 )
-async def reject_friendship_request() -> None:
+async def reject_friendship_request(
+    request_id: Annotated[PositiveInt, Path(example=42)],  # noqa: ARG001
+    access_token: Annotated[AccessTokenPayload, Depends(get_access_token)],  # noqa: ARG001
+) -> None:
     """Reject friendship request."""
 
 


### PR DESCRIPTION
 Во время работы над добавлением сваггера для эндпойнтов дружбы (#100), мы забыли прописать входные параметры для роута reject_friendship_request:

```python
async def reject_friendship_request() -> None:
#                                  ^^ тут
```

В рамках этой задачи необходимо добавить пропущенные параметры запроса - `request_id` и `access_token`.