### PR TITLE
Убрать version из компоуз файлов (#44)

### DIFF
--- a/envs/ci/db/docker-compose.yml
+++ b/envs/ci/db/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 name: wlss-ci-db
 
 services:

--- a/envs/ci/lint/docker-compose.yml
+++ b/envs/ci/lint/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 name: wlss-ci-lint
 
 services:

--- a/envs/ci/test/docker-compose.yml
+++ b/envs/ci/test/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 name: wlss-ci-test
 
 services:

--- a/envs/local/dev/docker-compose.yml
+++ b/envs/local/dev/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 name: wlss-local-dev
 
 services:

--- a/envs/local/test/docker-compose.yml
+++ b/envs/local/test/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 name: wlss-local-test
 
 services:

--- a/envs/qa/docker-compose.yml
+++ b/envs/qa/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 name: wlss-qa
 
 services:


### PR DESCRIPTION
Параметр `version` является deprecated, см [ссылку](https://docs.docker.com/compose/compose-file/04-version-and-name/) и не учитывается при парсинге компоуз-файлов.

В рамках этой задачи необходимо убрать параметр `version` из всех компоуз файлов проекта.