### PR TITLE
Форматирование списков команд в README.md (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/birthdaysgift/4fc310fa76bff267f6b9f1c9d00c812b/raw/pylint.json)
 ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/birthdaysgift/4fc310fa76bff267f6b9f1c9d00c812b/raw/pytest.json)
 
+
 Backend application for [Wish List Sharing Service](https://github.com/week-password/wisher).
 
 
@@ -27,7 +28,9 @@ Backend application for [Wish List Sharing Service](https://github.com/week-pass
 
 [Troubleshooting](#troubleshooting)
 
+
 ***
+
 
 ## [System requirements](#table-of-contents)
 
@@ -38,7 +41,6 @@ To develop this project you need to have the following software installed.
 - [Poetry 1.4.2](https://python-poetry.org/docs/)
 - [Python](https://www.python.org/) (see version in `pyproject.toml` file)
 
-***
 
 ## [First time setup](#table-of-contents)
 
@@ -46,22 +48,19 @@ Before start to setup project you have to meet [System requirements](#system-req
 
 Go to the project root directory.
 
-1. Setup git user for this repository.
+1. Set up local environment:
 ```bash
+# Set up git user for this repository
 source envs/local/dev/scripts/git/iam.sh
-```
 
-2. Create virtual environment and install dependencies.
-```bash
+# Create virtual environment and install dependencies.
 poetry install --with app,lint,test
-```
 
-3. Activate virtual environment.
-```bash
+# Activate virtual environment.
 poetry shell
 ```
 
-4. Upgrade pip within virtual environment.
+2. Upgrade pip within virtual environment:
 ```bash
 pip install --upgrade pip
 ```
@@ -71,27 +70,22 @@ pip install --upgrade pip
 
 To run application you need to do all steps from [First time setup](#first-time-setup) section.
 
-1. Create `.env` file.
+1. Run services and app:
 ```bash
+# Create .env file
 source envs/local/dev/env.sh
-```
 
-2. Run services.
-```bash
+# Run services.
 docker compose --file=envs/local/dev/docker-compose.yml up --detach
-```
 
-3. Apply migrations.
-```bash
+# Apply migrations.
 WLSS_ENV=local/dev alembic upgrade head
-```
 
-4. Run FastAPI.
-```bash
+# Run development server.
 WLSS_ENV=local/dev uvicorn src.app:app --reload
 ```
 
-5. Check health status.
+2. Check application health status:
 ```bash
 curl --request GET http://localhost:8000/health
 ```
@@ -103,23 +97,18 @@ To run linters you need to do all steps from [First time setup](#first-time-setu
 
 Linters order below is a preferred way to run and fix them one by one.
 
-1. Mypy.
+Run any linter you need or all of them at once:
 ```bash
+# Run mypy.
 mypy
-```
 
-2. Ruff.
-```bash
+# Run ruff.
 ruff check src tests
-```
 
-3. Flake8.
-```bash
+# Run flake8.
 flake8
-```
 
-4. Pylint.
-```bash
+# Run pylnig.
 pylint src tests
 ```
 
@@ -128,66 +117,64 @@ pylint src tests
 
 To run tests you need to do all steps from [First time setup](#first-time-setup) section.
 
-1. Create `.env` file.
+1. Run services and tests:
 ```bash
+# Create .env file
 source envs/local/test/env.sh
-```
 
-2. Run services.
-```bash
+# Run services.
 docker compose --file=envs/local/test/docker-compose.yml up --detach
-```
 
-3. Apply migrations.
-```bash
+# Apply migrations.
 WLSS_ENV=local/test alembic upgrade head
-```
 
-- Pytest.
-```bash
+# Run pytest.
 WLSS_ENV=local/test pytest --cov=src
 ```
 
-- Coverage report.
+Also you can choose one of the following ways of running tests:
+
+- Tests with html coverage report:
 ```bash
-coverage html
+WLSS_ENV=local/test pytest --cov=src ; coverage html
 ```
 
-- Report with contexts.
+- Tests with execution contexts in report:
 ```bash
 WLSS_ENV=local/test pytest --cov=src --cov-context=test ; coverage html --show-contexts --no-skip-covered
 ```
+
 
 ## [Working with migrations](#table-of-contents)
 
 Following examples will use `local/test` environment, but you can use any other value for `$WLSS_ENV` you need.
 
-- Generate new migration.
+- Generate new migration:
 ```bash
 WLSS_ENV=local/test alembic revision --autogenerate -m "migration message"
 ```
 
-- Apply all migrations.
+- Apply all migrations:
 ```bash
 WLSS_ENV=local/test alembic upgrade head
 ```
 
-- Apply migrations up to particular revision.
+- Apply migrations up to particular revision:
 ```bash
 WLSS_ENV=local/test alembic upgrade 746039e79eb3
 ```
 
-- Downgrade certain number of migrations.
+- Downgrade certain number of migrations:
 ```bash
 WLSS_ENV=local/test alembic downgrade -2
 ```
 
-- Downgrade migrations to particular revision.
+- Downgrade migrations to particular revision:
 ```bash
 WLSS_ENV=local/test alembic upgrade 746039e79eb3
 ```
 
-- Autoformat revision code if you changed it by hand.
+- Autoformat revision code if you changed it by hand:
 ```bash
 black --line-length=120 migrations
 ```
@@ -197,14 +184,14 @@ black --line-length=120 migrations
 
 _Only users with write access are able to deploy._
 
-1. Fetch the last version of the `deployed/qa` tag.
+1. Fetch the last version of the `deployed/qa` tag:
 ```bash
 git fetch origin +refs/tags/deployed/qa:refs/tags/deployed/qa
 ```
 
 2. Checkout to branch/commit you want to deploy.
 
-3. Create and push new version of the `deployed/qa` tag.
+3. Create and push new version of the `deployed/qa` tag:
 ```bash
 git tag --annotate --force deployed/qa --message ''
 git push origin deployed/qa --force


### PR DESCRIPTION
Сейчас разделы со списками команд отформатированы так, что каждая команда описана в отдельном блоке форматирования:

![image](https://github.com/week-password/wisher-backend/assets/35929293/afae69b5-042c-42fa-a4d2-4bb165f0ecac)

Выглядит неплохо и читается хорошо, но, кажется, это можно ещё улучшить. В результате [обсуждения](https://github.com/week-password/wisher-backend/discussions/45) было принято решение немного изменить форматирование.

В рамках этой задачи предлагается изменить форматирование списков команд таким образом, чтобы все команды были описаны в одном блоке форматирования:

![image](https://github.com/week-password/wisher-backend/assets/35929293/7006f7f3-7068-4bb5-84ed-da94e4f231ae)

У этого подхода есть несколько преимуществ перед предыдущим:

- **Компактность**
  Со временем README.md будет разрастаться всё больше, будет появляться больше разделов и в каждом разделе будет больше команд. И при описании всех команд раздела в одном блоке форматирования, весь раздел занимает меньше места.

- **Удобство**
  Когда все команды описаны в одном разделе в виде баш синтаксиса с комментариями это позволяет выделить весь блок целиком и запустить сразу все команды, вместо того чтобы выполнять их по одной.

***

В будущем на основе этого подхода можно будет разработать автоматизацию проверки корректности README.md. Это может быть скрипт, который парсит ридми, находит там подобные блоки баш кода и запускает в изолированом контейнере.