### PR TITLE
Поправить проверку пустых миграций (#174)

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -107,14 +107,9 @@ def run_migrations_online() -> None:
 
 @write_hooks.register("check_empty_migration")
 def check_empty_migration(revision_path, options):
-    from pathlib import Path
     from textwrap import dedent
 
-    MIGRATIONS_DIR = Path(__file__).parent
-
-    migration_files = list(MIGRATIONS_DIR.glob("versions/*.py"))
-
-    with migration_files[-1].open() as f:
+    with open(revision_path) as f:
         empty_upgrade = dedent(
             """
             def upgrade() -> None:
@@ -136,10 +131,16 @@ def check_empty_migration(revision_path, options):
             print(
                 dedent(
                     """
-                    You've created an empty migration file.
-
-                    Maybe you forgot to register your model in alembic.ini config?
-                    Double check 'models_packages' option in configuration file.
+                    +---------------------------- WARNING -----------------------------+
+                    |                                                                  |
+                    | You've created an empty migration file.                          |
+                    |                                                                  |
+                    | Maybe you forgot to register your model in alembic.ini config?   |
+                    |                                                                  |
+                    | Double check 'models_packages' option in configuration file.     |
+                    | Remove empty migration and create a new one.                     |
+                    |                                                                  |
+                    +---------------------------- WARNING -----------------------------+
                     """
                 )
             )


### PR DESCRIPTION
Во время работы над добавлением PostgreSQL (#29) мы добавили кастомный хук для алембика, который должен проверять последнюю созданную миграцию, и предупреждать пользователя если была сгенерирована пустая миграция.

Со временем выяснилось, что этот хук работает неправильно. Когда в репозитории появилось много миграций, оказалось, что хук не проверяет **последнюю** сгенерированную миграцию. В таком случае даже если последняя сгенерированная миграция оказалась пустой, мы не получим никаких предупреждений от этого хука.

В процессе дебаггинга выяснилось, что `list(MIGRATIONS_DIR.glob("versions/*.py"))` возвращает файлы не в алфавитном порядке. Поэтому такой код открывает не последний файл, а какой-то другой:
```python
MIGRATIONS_DIR = Path(__file__).parent

migration_files = list(MIGRATIONS_DIR.glob("versions/*.py"))

with migration_files[-1].open() as f:
```

Чтобы исправить эту ошибку было принято решение использовать путь до сгенерированной миграции, который даёт нам сам алембик в первом аргументе хука:
```python
@write_hooks.register("check_empty_migration")
def check_empty_migration(revision_path, options):
                          ^^^ сюда придёт путь до сгенерированной миграции
```
вместо того, чтобы выполнять поиск этой миграции "вручную" через `.glob()`.

В рамках этой задачи необходимо исправить работу хука алембика, проверяющего пустые миграции.