### PR TITLE
Добавить pip upgrade в README.md (#176)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ poetry install --with app,lint,test
 poetry shell
 ```
 
+4. Upgrade pip within virtual environment.
+```bash
+pip install --upgrade pip
+```
+
 
 ## [Run app](#table-of-contents)
 


### PR DESCRIPTION
В рамках этой задачи необходимо добавить команду `pip install --upgrade pip` в раздел "First time setup" в `README.md`, чтобы разработчики не получали ворнинги об устаревшей версии pip в консоли и работали с последней версией пакетного pip.