### PR TITLE
 Поправить примеры запросов в сваггере (#182)

### DIFF
--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -55,7 +55,7 @@ async def create_session(
     credentials: Annotated[  # noqa: ARG001
         schemas.Credentials,
         Body(
-            examples={
+            openapi_examples={
                 "With login": {
                     "description": "Sign In via login and password.",
                     "value": {


### PR DESCRIPTION
 После обновления fastapi и pydantic (#125) некоторые примеры реквестов в сваггере перестали отображаться. Это связано с тем, что в новой версии фастапи вместо поля `examples` необходимо использовать `openapi_examples`.

В рамках этой задачи необходимо поправить отображение примеров реквестов в сваггере.