### PR TITLE
Поправить путь до .env файла при деплое на QA (#186)

### DIFF
--- a/envs/qa/deploy/docker-compose.yml
+++ b/envs/qa/deploy/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ../../..  # path from the corrent file to the project root dir
       dockerfile: envs/qa/deploy/Dockerfile  # path from the project root dir to the Dockerfile
     environment:
-      - WLSS_ENV=qa
+      - WLSS_ENV=qa/deploy
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Во время работы над переносом содержимого envs/qa в envs/qa/deploy (#179) мы забыли поправить переменную WLSS_ENV, которая используется для поиска файла конфигурации.

В рамках этой задачи необходимо это исправить