### PR TITLE
Зарегистрировать в alembic.ini пропущенные модели (#188)

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -7,8 +7,11 @@ script_location = ./migrations
 # absolute paths to the packages with models definitions
 models_packages =
     src.account.models,
+    src.auth.models,
     src.file.models,
+    src.friendship.models,
     src.profile.models,
+    src.wish.models,
 
 # template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
 file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s


### PR DESCRIPTION
Во время переноса реализации MVP из прототипа (#184) мы забыли зарегистрировать некоторые модели в alembic.ini файле.

Почему алембик смог сгенерировать миграции для этих моделей не смотря на то, что они не зарегистрированы? Возможно потому что через цепочку импортов в других модулях эти модели всё таки успевают вычислиться до того, как алембик начинает сканирование. В любом случае явное лучше неявного поэтому надо бы их явно прописать.