### PR TITLE
Добавить тест для create_wish_booking (#190)

### DIFF
--- a/tests/test_wish/test_create_wish_booking.py
+++ b/tests/test_wish/test_create_wish_booking.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import dirty_equals
 import pytest
+from sqlalchemy import select
+
+from src.shared.database import Base
+from src.wish.models import WishBooking
+from tests.utils.mocks.models import __eq__
 
 
 @pytest.mark.anyio
@@ -23,6 +30,32 @@ async def test_create_wish_booking_returns_201_with_correct_response(f):
         "created_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
         "wish_id": 1,
     }
+
+
+@pytest.mark.anyio
+@pytest.mark.fixtures({
+    "access_token": "access_token",
+    "client": "client",
+    "db": "db_with_two_friend_accounts_and_one_wish",
+})
+async def test_create_wish_booking_creates_objects_in_db_correctly(f):
+    result = await f.client.post(  # noqa: F841
+        "/accounts/2/wishes/1/bookings",
+        headers={"Authorization": f"Bearer {f.access_token}"},
+        json={"account_id": 1, "wish_id": 1},
+    )
+
+    with patch.object(Base, "__eq__", __eq__):
+        wish_bookings = (await f.db.execute(select(WishBooking))).scalars().all()
+        assert wish_bookings == [
+            WishBooking(
+                id=dirty_equals.IsPositiveInt,
+                account_id=1,
+                created_at=dirty_equals.IsDatetime(enforce_tz=True),
+                updated_at=dirty_equals.IsDatetime(enforce_tz=True),
+                wish_id=1,
+            ),
+        ]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Во время работы над переносом реализации MVP из прототипа (#184) мы забыли добавить тест, который проверяет состояние бд после создания wish booking для эндпойнта create_wish_booking.

В рамках этой задачи необходимо добавить этот тест.