### PR TITLE
Переработать использование типов (#173)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -7,7 +7,10 @@ external = [
 
     # flake8-rst-docstrings
     "RST214",
-    "RST215"
+    "RST215",
+
+    # flake8-spellcheck
+    "SC200",
 ]
 
 ignore = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -2435,6 +2435,25 @@ files = [
 ]
 
 [[package]]
+name = "wlss"
+version = "0.1.0"
+description = "Library used by WLSS backend."
+category = "dev"
+optional = false
+python-versions = "3.11.*"
+files = []
+develop = false
+
+[package.dependencies]
+typing-extensions = "^4.5.0"
+
+[package.source]
+type = "git"
+url = "https://github.com/week-password/wlss-backend-lib.git"
+reference = "e2c11e344d096579e2582c45fb08007195ebcc8d"
+resolved_reference = "e2c11e344d096579e2582c45fb08007195ebcc8d"
+
+[[package]]
 name = "wrapt"
 version = "1.15.0"
 description = "Module for decorators, wrappers and monkey patching."
@@ -2522,4 +2541,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "8f0dce4b0646f8013bf8e2073d47529e0636cfb533e14c5957d3bbc3b958bc09"
+content-hash = "7144b01855f2a8f459d54031432bb3b18d09485342c5526f988ae696925bcf8e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ pyjwt = "2.8.0"
 python-dotenv = "1.0.0"
 sqlalchemy = {extras = ["asyncio"], version = "2.0.12"}
 varname = "0.12.0"
+wlss = {git = "https://github.com/week-password/wlss-backend-lib.git", rev = "e2c11e344d096579e2582c45fb08007195ebcc8d"}
 
 
 [tool.poetry.group.lint]

--- a/src/account/columns.py
+++ b/src/account/columns.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from wlss.account.types import AccountEmail, AccountLogin
+
+from src.shared.columns import StrColumn
+
+
+# pylint: disable-next=abstract-method,too-many-ancestors
+class AccountEmailColumn(StrColumn):
+    type_ = AccountEmail
+
+
+# pylint: disable-next=abstract-method,too-many-ancestors
+class AccountLoginColumn(StrColumn):
+    type_ = AccountLogin

--- a/src/account/controllers.py
+++ b/src/account/controllers.py
@@ -9,6 +9,7 @@ from src.profile.models import Profile
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
+    from wlss.account.types import AccountLogin
 
     from src.account.schemas import NewAccountWithProfile
 
@@ -21,7 +22,7 @@ async def create_account(request_data: NewAccountWithProfile, session: AsyncSess
 
 
 async def get_account_id(
-    account_login: str,
+    account_login: AccountLogin,
     current_account: Account,  # noqa: ARG001
     session: AsyncSession,
 ) -> schemas.AccountId:

--- a/src/account/fields.py
+++ b/src/account/fields.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import PlainSerializer, PlainValidator, WithJsonSchema
+from pydantic.json_schema import GenerateJsonSchema
+from pydantic_core.core_schema import str_schema
+from wlss.account.types import AccountEmail, AccountLogin, AccountPassword
+
+
+AccountEmailField = Annotated[
+    AccountEmail,
+    PlainValidator(AccountEmail),
+    PlainSerializer(lambda v: v.value, return_type=str),
+    WithJsonSchema(GenerateJsonSchema().generate(
+        str_schema(
+            max_length=AccountEmail.LENGTH_MAX.value,
+            min_length=AccountEmail.LENGTH_MIN.value,
+            pattern=AccountEmail.REGEXP.pattern,
+        ),
+    )),
+]
+
+
+AccountLoginField = Annotated[
+    AccountLogin,
+    PlainValidator(AccountLogin),
+    PlainSerializer(lambda v: v.value, return_type=str),
+    WithJsonSchema(GenerateJsonSchema().generate(
+        str_schema(
+            max_length=AccountLogin.LENGTH_MAX.value,
+            min_length=AccountLogin.LENGTH_MIN.value,
+            pattern=AccountLogin.REGEXP.pattern,
+        ),
+    )),
+]
+
+
+AccountPasswordField = Annotated[
+    AccountPassword,
+    PlainValidator(AccountPassword),
+    WithJsonSchema(GenerateJsonSchema().generate(
+        str_schema(
+            max_length=AccountPassword.LENGTH_MAX.value,
+            min_length=AccountPassword.LENGTH_MIN.value,
+        ),
+    )),
+]

--- a/src/account/routes.py
+++ b/src/account/routes.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Body, Depends, Path, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.account import controllers, schemas
+from src.account.fields import AccountLoginField
 from src.account.models import Account
 from src.auth.dependencies import get_account_from_access_token
 from src.shared import swagger as shared_swagger
@@ -89,7 +90,7 @@ async def create_account(
     summary="Get Account Id.",
 )
 async def get_account_id(
-    account_login: Annotated[str, Path(example="john_doe")],
+    account_login: Annotated[AccountLoginField, Path(example="john_doe")],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
 ) -> schemas.AccountId:

--- a/src/account/schemas.py
+++ b/src/account/schemas.py
@@ -1,27 +1,25 @@
 from __future__ import annotations
 
-from datetime import datetime
-
-from pydantic import PositiveInt
-
+from src.account.fields import AccountEmailField, AccountLoginField, AccountPasswordField
 from src.profile.schemas import NewProfile, Profile
+from src.shared.fields import IdField, UtcDatetimeField
 from src.shared.schemas import Schema
 
 
 class NewAccount(Schema):
     """Account data which is going to be created during sign up process."""
 
-    email: str
-    login: str
-    password: str
+    email: AccountEmailField
+    login: AccountLoginField
+    password: AccountPasswordField
 
 
 class Account(Schema):
-    id: PositiveInt  # noqa: A003
+    id: IdField  # noqa: A003
 
-    created_at: datetime
-    email: str
-    login: str
+    created_at: UtcDatetimeField
+    email: AccountEmailField
+    login: AccountLoginField
 
 
 class NewAccountWithProfile(Schema):
@@ -35,12 +33,12 @@ class AccountWithProfile(Schema):
 
 
 class AccountId(Schema):
-    id: PositiveInt  # noqa: A003
+    id: IdField  # noqa: A003
 
 
 class AccountLogin(Schema):
-    login: str
+    login: AccountLoginField
 
 
 class AccountEmail(Schema):
-    email: str
+    email: AccountEmailField

--- a/src/auth/controllers.py
+++ b/src/auth/controllers.py
@@ -14,8 +14,8 @@ from src.auth.exceptions import (
 if TYPE_CHECKING:
     from uuid import UUID
 
-    from pydantic import PositiveInt
     from sqlalchemy.ext.asyncio import AsyncSession
+    from wlss.shared.types import Id
 
 
 async def create_session(credentials: schemas.Credentials, session: AsyncSession) -> schemas.SessionWithTokens:
@@ -36,7 +36,7 @@ async def create_session(credentials: schemas.Credentials, session: AsyncSession
 
 
 async def refresh_tokens(
-    account_id: PositiveInt,
+    account_id: Id,
     session_id: UUID,
     current_account: Account,
     session: AsyncSession,
@@ -51,7 +51,7 @@ async def refresh_tokens(
 
 
 async def delete_session(
-    account_id: PositiveInt,
+    account_id: Id,
     session_id: UUID,
     current_account: Account,
     session: AsyncSession,
@@ -67,7 +67,7 @@ async def delete_session(
 
 
 async def delete_all_sessions(
-    account_id: PositiveInt,
+    account_id: Id,
     current_account: Account,
     session: AsyncSession,
 ) -> None:

--- a/src/auth/dependencies.py
+++ b/src/auth/dependencies.py
@@ -34,7 +34,7 @@ async def get_account_from_access_token(
         raise InvalidCredentialsError()  # noqa: TRY200, B904
 
     datetime_now = datetime.now(tz=timezone.utc)
-    if datetime_now > payload.expires_at:
+    if datetime_now > payload.expires_at.value:
         raise TokenExpiredError()
 
     try:  # pylint: disable=too-many-try-statements
@@ -66,7 +66,7 @@ async def get_account_from_refresh_token(
         raise InvalidCredentialsError()  # noqa: TRY200, B904
 
     datetime_now = datetime.now(tz=timezone.utc)
-    if datetime_now > payload.expires_at:
+    if datetime_now > payload.expires_at.value:
         raise TokenExpiredError()
 
     try:  # pylint: disable=too-many-try-statements

--- a/src/auth/models.py
+++ b/src/auth/models.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, delete, ForeignKey, UUID
+from sqlalchemy import delete, ForeignKey, UUID
 from sqlalchemy.orm import Mapped, mapped_column
+from wlss.shared.types import Id, UtcDatetime
 
+from src.shared.columns import UtcDatetimeColumn
 from src.shared.database import Base
 from src.shared.datetime import utcnow
 
@@ -23,11 +24,9 @@ class Session(Base):  # pylint: disable=too-few-public-methods
 
     id: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True, default=uuid.uuid4)  # noqa: A003
 
-    account_id: Mapped[int] = mapped_column(ForeignKey("account.id"), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow, nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utcnow, nullable=False, onupdate=utcnow,
-    )
+    account_id: Mapped[Id] = mapped_column(ForeignKey("account.id"), nullable=False)
+    created_at: Mapped[UtcDatetime] = mapped_column(UtcDatetimeColumn, default=utcnow, nullable=False)
+    updated_at: Mapped[UtcDatetime] = mapped_column(UtcDatetimeColumn, default=utcnow, nullable=False, onupdate=utcnow)
 
     async def delete(self: Self, session: AsyncSession) -> None:
         query = delete(Session).where(Session.id == self.id)

--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 from typing import Annotated
-from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, Path, status
-from pydantic import PositiveInt
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.account.models import Account
@@ -12,6 +10,7 @@ from src.auth import controllers, schemas
 from src.auth.dependencies import get_account_from_access_token, get_account_from_refresh_token
 from src.shared import swagger as shared_swagger
 from src.shared.database import get_session
+from src.shared.fields import IdField, UuidField
 
 
 router = APIRouter(tags=["auth"])
@@ -122,8 +121,8 @@ async def create_session(
     summary="Generate new access and refresh tokens for particular auth session",
 )
 async def refresh_tokens(
-    account_id: Annotated[PositiveInt, Path(example=42)],
-    session_id: Annotated[UUID, Path(example="b9dd3a32-aee8-4a6b-a519-def9ca30c9ec")],
+    account_id: Annotated[IdField, Path(example=42)],
+    session_id: Annotated[UuidField, Path(example="b9dd3a32-aee8-4a6b-a519-def9ca30c9ec")],
     current_account: Annotated[Account, Depends(get_account_from_refresh_token)],
     session: AsyncSession = Depends(get_session),
 ) -> schemas.Tokens:
@@ -145,8 +144,8 @@ async def refresh_tokens(
     summary="Sign Out for particular auth session.",
 )
 async def delete_session(
-    account_id: Annotated[PositiveInt, Path(example=42)],
-    session_id: Annotated[UUID, Path(example="b9dd3a32-aee8-4a6b-a519-def9ca30c9ec")],
+    account_id: Annotated[IdField, Path(example=42)],
+    session_id: Annotated[UuidField, Path(example="b9dd3a32-aee8-4a6b-a519-def9ca30c9ec")],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
 ) -> None:
@@ -168,7 +167,7 @@ async def delete_session(
     summary="Sign Out from all sessions.",
 )
 async def delete_all_sessions(
-    account_id: Annotated[PositiveInt, Path(example=42)],
+    account_id: Annotated[IdField, Path(example=42)],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
 ) -> None:

--- a/src/file/columns.py
+++ b/src/file/columns.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from wlss.file.types import FileSize
+
+from src.shared.columns import PositiveIntColumn
+
+
+# pylint: disable-next=abstract-method,too-many-ancestors
+class FileSizeColumn(PositiveIntColumn):
+    type_ = FileSize

--- a/src/file/fields.py
+++ b/src/file/fields.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Annotated, TYPE_CHECKING
+
+from pydantic import PlainSerializer, PlainValidator, WithJsonSchema
+from pydantic.json_schema import GenerateJsonSchema
+from pydantic_core.core_schema import int_schema
+from wlss.file.types import FileSize
+
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def _validate_file_size(value: Any) -> FileSize:  # noqa: ANN401
+    if isinstance(value, FileSize):
+        value = value.value
+    return FileSize(value)
+
+
+FileSizeField = Annotated[
+    FileSize,
+    PlainValidator(_validate_file_size),
+    PlainSerializer(lambda v: v.value, return_type=int),
+    WithJsonSchema(GenerateJsonSchema().generate(
+        int_schema(
+            ge=FileSize.VALUE_MIN.value,
+            le=FileSize.VALUE_MAX.value,
+        ),
+    )),
+]

--- a/src/file/models.py
+++ b/src/file/models.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 import typing
 import uuid
-from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, Enum, Integer, select, String, UUID
+from sqlalchemy import Enum, select, String, UUID
 from sqlalchemy.orm import Mapped, mapped_column
+from wlss.file.types import FileSize
+from wlss.shared.types import UtcDatetime
 
 from src.file import exceptions
+from src.file.columns import FileSizeColumn
 from src.file.enums import Extension, MimeType
+from src.shared.columns import UtcDatetimeColumn
 from src.shared.database import Base
 from src.shared.datetime import utcnow
 
@@ -26,14 +29,12 @@ class File(Base):
 
     id: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True, default=uuid.uuid4)  # noqa: A003
 
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow, nullable=False)
+    created_at: Mapped[UtcDatetime] = mapped_column(UtcDatetimeColumn, default=utcnow, nullable=False)
     extension: Mapped[Extension] = mapped_column(Enum(Extension, name="extension_enum"), nullable=False)
     mime_type: Mapped[MimeType] = mapped_column(Enum(MimeType, name="mime_type_enum"), nullable=False)
     name: Mapped[str] = mapped_column(String, nullable=False)
-    size: Mapped[int] = mapped_column(Integer, nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utcnow, nullable=False, onupdate=utcnow,
-    )
+    size: Mapped[FileSize] = mapped_column(FileSizeColumn, nullable=False)
+    updated_at: Mapped[UtcDatetime] = mapped_column(UtcDatetimeColumn, default=utcnow, nullable=False, onupdate=utcnow)
 
     @classmethod
     async def create_file(cls: type[File], session: AsyncSession, new_file: NewFile) -> File:

--- a/src/file/routes.py
+++ b/src/file/routes.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pathlib
 from typing import Annotated
-from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Path, status
 from fastapi.responses import FileResponse
@@ -14,6 +13,7 @@ from src.file import controllers, schemas
 from src.file.dependencies import get_new_file, get_tmp_dir
 from src.shared import swagger as shared_swagger
 from src.shared.database import get_session
+from src.shared.fields import UuidField
 
 
 router = APIRouter(tags=["file"])
@@ -69,7 +69,7 @@ async def create_file(
 )
 async def get_file(
     background_tasks: BackgroundTasks,
-    file_id: Annotated[UUID, Path(example="47b3d7a9-d7d3-459a-aac1-155997775a0e")],
+    file_id: Annotated[UuidField, Path(example="47b3d7a9-d7d3-459a-aac1-155997775a0e")],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     tmp_dir: Annotated[pathlib.Path, Depends(get_tmp_dir)],
     session: AsyncSession = Depends(get_session),

--- a/src/file/schemas.py
+++ b/src/file/schemas.py
@@ -1,21 +1,19 @@
 from __future__ import annotations
 
 from pathlib import Path
-from uuid import UUID
 
-from pydantic import Field
-
-from src.file.constants import MEGABYTE
 from src.file.enums import Extension, MimeType
+from src.file.fields import FileSizeField
+from src.shared.fields import UuidField
 from src.shared.schemas import Schema
 
 
 class File(Schema):
-    id: UUID  # noqa: A003
+    id: UuidField  # noqa: A003
 
     extension: Extension
     mime_type: MimeType
-    size: int = Field(le=10 * MEGABYTE)
+    size: FileSizeField
 
 
 class NewFile(Schema):
@@ -23,5 +21,5 @@ class NewFile(Schema):
     extension: Extension
     name: str
     mime_type: MimeType
-    size: int = Field(le=10 * MEGABYTE)
+    size: FileSizeField
     tmp_file_path: Path

--- a/src/friendship/controllers.py
+++ b/src/friendship/controllers.py
@@ -14,12 +14,12 @@ from src.friendship.models import FriendshipRequest
 
 
 if TYPE_CHECKING:
-    from pydantic import PositiveInt
     from sqlalchemy.ext.asyncio import AsyncSession
+    from wlss.shared.types import Id
 
 
 async def get_friends(
-    account_id: PositiveInt,
+    account_id: Id,
     current_account: Account,  # noqa: ARG001
     session: AsyncSession,
 ) -> schemas.Friends:
@@ -53,7 +53,7 @@ async def create_friendship_request(
 
 
 async def cancel_friendship_request(
-    request_id: PositiveInt,
+    request_id: Id,
     current_account: Account,
     session: AsyncSession,
 ) -> None:
@@ -64,7 +64,7 @@ async def cancel_friendship_request(
 
 
 async def accept_friendship_request(
-    request_id: PositiveInt,
+    request_id: Id,
     current_account: Account,
     session: AsyncSession,
 ) -> schemas.Friendships:
@@ -76,7 +76,7 @@ async def accept_friendship_request(
 
 
 async def reject_friendship_request(
-    request_id: PositiveInt,
+    request_id: Id,
     current_account: Account,
     session: AsyncSession,
 ) -> schemas.FriendshipRequest:
@@ -88,7 +88,7 @@ async def reject_friendship_request(
 
 
 async def get_friendship_requests(
-    account_id: PositiveInt,
+    account_id: Id,
     current_account: Account,  # noqa: ARG001
     session: AsyncSession,
 ) -> schemas.FriendshipRequests:

--- a/src/friendship/models.py
+++ b/src/friendship/models.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, delete, Enum, ForeignKey, Integer
+from sqlalchemy import delete, Enum, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
+from wlss.shared.types import Id, UtcDatetime
 
 from src.friendship.enums import FriendshipRequestStatus
 from src.friendship.exceptions import CannotRejectFriendshipRequest
+from src.shared.columns import IdColumn, UtcDatetimeColumn
 from src.shared.database import Base
 from src.shared.datetime import utcnow
 
@@ -24,32 +25,28 @@ class Friendship(Base):  # pylint: disable=too-few-public-methods
 
     __tablename__ = "friendship"
 
-    account_id: Mapped[int] = mapped_column(ForeignKey("account.id"), nullable=False, primary_key=True)
-    friend_id: Mapped[int] = mapped_column(ForeignKey("account.id"), nullable=False, primary_key=True)
+    account_id: Mapped[Id] = mapped_column(ForeignKey("account.id"), nullable=False, primary_key=True)
+    friend_id: Mapped[Id] = mapped_column(ForeignKey("account.id"), nullable=False, primary_key=True)
 
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow, nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utcnow, nullable=False, onupdate=utcnow,
-    )
+    created_at: Mapped[UtcDatetime] = mapped_column(UtcDatetimeColumn, default=utcnow, nullable=False)
+    updated_at: Mapped[UtcDatetime] = mapped_column(UtcDatetimeColumn, default=utcnow, nullable=False, onupdate=utcnow)
 
 
 class FriendshipRequest(Base):
 
     __tablename__ = "friendship_request"
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)  # noqa: A003
+    id: Mapped[Id] = mapped_column(IdColumn, primary_key=True)  # noqa: A003
 
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow, nullable=False)
-    receiver_id: Mapped[int] = mapped_column(ForeignKey("account.id"), nullable=False)
-    sender_id: Mapped[int] = mapped_column(ForeignKey("account.id"), nullable=False)
+    created_at: Mapped[UtcDatetime] = mapped_column(UtcDatetimeColumn, default=utcnow, nullable=False)
+    receiver_id: Mapped[Id] = mapped_column(ForeignKey("account.id"), nullable=False)
+    sender_id: Mapped[Id] = mapped_column(ForeignKey("account.id"), nullable=False)
     status: Mapped[FriendshipRequestStatus] = mapped_column(
         Enum(FriendshipRequestStatus, name="friendship_request_status_enum"),
         default=FriendshipRequestStatus.PENDING,
         nullable=False,
     )
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utcnow, nullable=False, onupdate=utcnow,
-    )
+    updated_at: Mapped[UtcDatetime] = mapped_column(UtcDatetimeColumn, default=utcnow, nullable=False, onupdate=utcnow)
 
     @classmethod
     async def create(

--- a/src/friendship/routes.py
+++ b/src/friendship/routes.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, Path, status
-from pydantic import PositiveInt
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.account.models import Account
@@ -11,6 +10,7 @@ from src.auth.dependencies import get_account_from_access_token
 from src.friendship import controllers, schemas
 from src.shared import swagger as shared_swagger
 from src.shared.database import get_session
+from src.shared.fields import IdField
 
 
 router = APIRouter(tags=["friendship"])
@@ -66,7 +66,7 @@ router = APIRouter(tags=["friendship"])
     summary="Get friends.",
 )
 async def get_friends(
-    account_id: Annotated[PositiveInt, Path(example=15)],
+    account_id: Annotated[IdField, Path(example=15)],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
 ) -> schemas.Friends:
@@ -125,7 +125,7 @@ async def create_friendship_request(
     summary="Cancel friendship request.",
 )
 async def cancel_friendship_request(
-    request_id: Annotated[PositiveInt, Path(example=42)],
+    request_id: Annotated[IdField, Path(example=42)],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
 ) -> None:
@@ -164,7 +164,7 @@ async def cancel_friendship_request(
     summary="Accept friendship request.",
 )
 async def accept_friendship_request(
-    request_id: Annotated[PositiveInt, Path(example=42)],
+    request_id: Annotated[IdField, Path(example=42)],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
 ) -> schemas.Friendships:
@@ -198,7 +198,7 @@ async def accept_friendship_request(
     summary="Reject friendship request.",
 )
 async def reject_friendship_request(
-    request_id: Annotated[PositiveInt, Path(example=42)],
+    request_id: Annotated[IdField, Path(example=42)],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
 ) -> schemas.FriendshipRequest:
@@ -253,7 +253,7 @@ async def reject_friendship_request(
     summary="Get friendship requests.",
 )
 async def get_friendship_requests(
-    account_id: Annotated[PositiveInt, Path(example=42)],
+    account_id: Annotated[IdField, Path(example=42)],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
 ) -> schemas.FriendshipRequests:

--- a/src/friendship/schemas.py
+++ b/src/friendship/schemas.py
@@ -1,23 +1,22 @@
 from __future__ import annotations
 
-from datetime import datetime
 from uuid import UUID
 
-from pydantic import PositiveInt
-
 from src.friendship.enums import FriendshipRequestStatus
+from src.profile.fields import ProfileDescriptionField, ProfileNameField
+from src.shared.fields import IdField, UtcDatetimeField
 from src.shared.schemas import Schema
 
 
 class NewFriendship(Schema):
-    account_id: PositiveInt
-    friend_id: PositiveInt
+    account_id: IdField
+    friend_id: IdField
 
 
 class Friendship(Schema):
-    account_id: PositiveInt
-    created_at: datetime
-    friend_id: PositiveInt
+    account_id: IdField
+    created_at: UtcDatetimeField
+    friend_id: IdField
 
 
 class Friendships(Schema):
@@ -25,11 +24,11 @@ class Friendships(Schema):
 
 
 class FriendshipRequest(Schema):
-    id: PositiveInt  # noqa: A003
+    id: IdField  # noqa: A003
 
-    created_at: datetime
-    receiver_id: PositiveInt
-    sender_id: PositiveInt
+    created_at: UtcDatetimeField
+    receiver_id: IdField
+    sender_id: IdField
     status: FriendshipRequestStatus
 
 
@@ -38,8 +37,8 @@ class FriendshipRequests(Schema):
 
 
 class NewFriendshipRequest(Schema):
-    receiver_id: PositiveInt
-    sender_id: PositiveInt
+    receiver_id: IdField
+    sender_id: IdField
 
 
 class Friend(Schema):
@@ -49,18 +48,18 @@ class Friend(Schema):
 
 
 class FriendAccount(Schema):
-    id: PositiveInt  # noqa: A003
+    id: IdField  # noqa: A003
 
 
 class FriendProfile(Schema):
-    account_id: PositiveInt
+    account_id: IdField
     avatar_id: UUID | None = None
-    description: str | None
-    name: str
+    description: ProfileDescriptionField | None
+    name: ProfileNameField
 
 
 class FriendFriendship(Schema):
-    created_at: datetime
+    created_at: UtcDatetimeField
 
 
 class Friends(Schema):

--- a/src/profile/columns.py
+++ b/src/profile/columns.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from wlss.profile.types import ProfileDescription, ProfileName
+
+from src.shared.columns import StrColumn
+
+
+# pylint: disable-next=abstract-method,too-many-ancestors
+class ProfileDescriptionColumn(StrColumn):
+    type_ = ProfileDescription
+
+
+# pylint: disable-next=abstract-method,too-many-ancestors
+class ProfileNameColumn(StrColumn):
+    type_ = ProfileName

--- a/src/profile/controllers.py
+++ b/src/profile/controllers.py
@@ -7,12 +7,12 @@ from src.profile import schemas
 
 
 if TYPE_CHECKING:
-    from pydantic import PositiveInt
     from sqlalchemy.ext.asyncio import AsyncSession
+    from wlss.shared.types import Id
 
 
 async def get_profile(
-    account_id: PositiveInt,
+    account_id: Id,
     current_account: Account,  # noqa: ARG001
     session: AsyncSession,
 ) -> schemas.Profile:
@@ -27,7 +27,7 @@ async def get_profile(
 
 
 async def update_profile(
-    account_id: PositiveInt,
+    account_id: Id,
     profile_update: schemas.ProfileUpdate,
     current_account: Account,  # noqa: ARG001
     session: AsyncSession,

--- a/src/profile/fields.py
+++ b/src/profile/fields.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import PlainSerializer, PlainValidator, WithJsonSchema
+from pydantic.json_schema import GenerateJsonSchema
+from pydantic_core.core_schema import str_schema
+from wlss.profile.types import ProfileDescription, ProfileName
+
+
+ProfileDescriptionField = Annotated[
+    ProfileDescription,
+    PlainValidator(ProfileDescription),
+    PlainSerializer(lambda v: v.value, return_type=str),
+    WithJsonSchema(GenerateJsonSchema().generate(
+        str_schema(
+            max_length=ProfileDescription.LENGTH_MAX.value,
+            min_length=ProfileDescription.LENGTH_MIN.value,
+            pattern=ProfileDescription.REGEXP.pattern,
+        ),
+    )),
+]
+
+
+ProfileNameField = Annotated[
+    ProfileName,
+    PlainValidator(ProfileName),
+    PlainSerializer(lambda v: v.value, return_type=str),
+    WithJsonSchema(GenerateJsonSchema().generate(
+        str_schema(
+            max_length=ProfileName.LENGTH_MAX.value,
+            min_length=ProfileName.LENGTH_MIN.value,
+            pattern=ProfileName.REGEXP.pattern,
+        ),
+    )),
+]

--- a/src/profile/routes.py
+++ b/src/profile/routes.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, Path, status
-from pydantic import PositiveInt
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.account.models import Account
@@ -11,6 +10,7 @@ from src.auth.dependencies import get_account_from_access_token
 from src.profile import controllers, schemas
 from src.shared import swagger as shared_swagger
 from src.shared.database import get_session
+from src.shared.fields import IdField
 
 
 router = APIRouter(tags=["profile"])
@@ -42,7 +42,7 @@ router = APIRouter(tags=["profile"])
     summary="Get Profile info.",
 )
 async def get_profile(
-    account_id: Annotated[PositiveInt, Path(example=42)],
+    account_id: Annotated[IdField, Path(example=42)],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
 ) -> schemas.Profile:
@@ -75,7 +75,7 @@ async def get_profile(
     summary="Update Profile info.",
 )
 async def update_profile(
-    account_id: Annotated[PositiveInt, Path(example=42)],
+    account_id: Annotated[IdField, Path(example=42)],
     profile_update: Annotated[
         schemas.ProfileUpdate,
         Body(

--- a/src/profile/schemas.py
+++ b/src/profile/schemas.py
@@ -2,25 +2,25 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from pydantic import PositiveInt
-
+from src.profile.fields import ProfileDescriptionField, ProfileNameField
+from src.shared.fields import IdField, UuidField
 from src.shared.schemas import Schema
 
 
 class NewProfile(Schema):
-    name: str
-    description: str | None = None
+    name: ProfileNameField
+    description: ProfileDescriptionField | None = None
 
 
 class Profile(Schema):
-    account_id: PositiveInt
+    account_id: IdField
 
     avatar_id: UUID | None = None
-    description: str | None = None
-    name: str
+    description: ProfileDescriptionField | None = None
+    name: ProfileNameField
 
 
 class ProfileUpdate(Schema):
-    avatar_id: UUID | None = None
-    description: str | None = None
-    name: str
+    avatar_id: UuidField | None = None
+    description: ProfileDescriptionField | None = None
+    name: ProfileNameField

--- a/src/shared/columns.py
+++ b/src/shared/columns.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, TypeVar
+
+from sqlalchemy import types
+from wlss.core.types import PositiveInt, Str, Type
+from wlss.shared.types import Id, UtcDatetime
+
+
+if TYPE_CHECKING:
+    from typing import Any, Self
+
+    from sqlalchemy.engine.interfaces import Dialect
+
+
+T = TypeVar("T")
+
+
+# pylint: disable-next=abstract-method,too-many-ancestors
+class TypeColumn(types.TypeDecorator[Type[T]]):
+    type_: type[Type[T]]
+
+    def process_bind_param(self: Self, value: Any | None, _: Dialect) -> T | None:  # noqa: SC200
+        if isinstance(value, self.type_):
+            return value.value
+        if value is None:
+            return None
+        raise NotImplementedError  # pragma: no cover
+
+    def process_result_value(self: Self, value: T | None, _: Dialect) -> Type[T] | None:
+        if value is None:
+            return None
+        return self.type_(value)
+
+
+# pylint: disable-next=abstract-method,too-many-ancestors
+class PositiveIntColumn(TypeColumn[int]):  # pylint: disable=too-many-ancestors
+    type_ = PositiveInt
+    impl = types.Integer()  # noqa: SC200
+
+
+# pylint: disable-next=abstract-method,too-many-ancestors
+class IdColumn(PositiveIntColumn):  # pylint: disable=too-many-ancestors
+    type_ = Id
+
+
+# pylint: disable-next=abstract-method,too-many-ancestors
+class StrColumn(TypeColumn[str]):  # pylint: disable=too-many-ancestors
+    type_ = Str
+    impl = types.String(length=type_.LENGTH_MAX.value if type_.LENGTH_MAX is not None else None)  # noqa: SC200
+
+
+# pylint: disable-next=abstract-method,too-many-ancestors
+class UtcDatetimeColumn(TypeColumn[datetime]):  # pylint: disable=too-many-ancestors
+    type_ = UtcDatetime
+    impl = types.DateTime(timezone=True)  # noqa: SC200

--- a/src/shared/datetime.py
+++ b/src/shared/datetime.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
+from wlss.shared.types import UtcDatetime
+
 
 if TYPE_CHECKING:
     from typing import Final
@@ -11,7 +13,7 @@ if TYPE_CHECKING:
 DATETIME_FORMAT: Final = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
-def utcnow() -> datetime:
+def utcnow() -> UtcDatetime:
     """Get timezone aware datetime with UTC timezone.
 
     There are two reasons of having this function instead of just using `datetime.now(tz=timezone.utc)` everywhere:
@@ -21,8 +23,8 @@ def utcnow() -> datetime:
            It means that we can not provide just `default=datetime.now` because it is not using UTC timezone.
            We also can not use `default=datetime.utcnow` because it returns timezone-naive datetime object.
 
-        2. Simply `utcnow()` is shorter than `datetime.now(tz=timezone.utc)`
+        2. Simply `utcnow()` is shorter than `UtcDatetime(datetime.now(tz=timezone.utc))`
 
     :returns: datetime
     """
-    return datetime.now(tz=timezone.utc)
+    return UtcDatetime(datetime.now(tz=timezone.utc))

--- a/src/shared/fields.py
+++ b/src/shared/fields.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, TYPE_CHECKING
+from uuid import UUID
+
+from pydantic import PlainSerializer, PlainValidator, WithJsonSchema
+from pydantic.json_schema import GenerateJsonSchema
+from pydantic_core.core_schema import datetime_schema, int_schema, uuid_schema
+from wlss.shared.types import Id, UtcDatetime
+
+from src.shared.datetime import DATETIME_FORMAT
+
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def _validate_id(value: Any) -> Id:  # noqa: ANN401
+    if isinstance(value, Id):
+        value = value.value
+    if isinstance(value, str):
+        value = int(value)
+    return Id(value)
+
+
+IdField = Annotated[
+    Id,
+    PlainValidator(_validate_id),
+    PlainSerializer(lambda v: v.value, return_type=int),
+    WithJsonSchema(GenerateJsonSchema().generate(
+        int_schema(
+            ge=Id.VALUE_MIN.value,
+        ),
+    )),
+]
+
+
+def _validate_utcdatetime(value: Any) -> UtcDatetime:  # noqa: ANN401,SC200
+    if isinstance(value, str):
+        value = datetime.fromisoformat(value)
+    return UtcDatetime(value)
+
+
+UtcDatetimeField = Annotated[
+    UtcDatetime,
+    PlainValidator(_validate_utcdatetime),  # noqa: SC200
+    PlainSerializer(lambda v: v.value.strftime(DATETIME_FORMAT), return_type=str),
+    WithJsonSchema(GenerateJsonSchema().generate(
+        datetime_schema(
+            tz_constraint="aware",
+        ),
+    )),
+]
+
+
+def _uuid_validator(value: Any) -> UUID:  # noqa: ANN401
+    if isinstance(value, UUID):
+        value = str(value)
+    return UUID(value)
+
+
+UuidField = Annotated[
+    UUID,
+    PlainValidator(_uuid_validator),
+    PlainSerializer(lambda v: str(v), return_type=str),  # pylint: disable=unnecessary-lambda
+    WithJsonSchema(GenerateJsonSchema().generate(
+        uuid_schema(
+            version=4,
+        ),
+    )),
+]

--- a/src/wish/columns.py
+++ b/src/wish/columns.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from wlss.wish.types import WishDescription, WishTitle
+
+from src.shared.columns import StrColumn
+
+
+# pylint: disable-next=abstract-method,too-many-ancestors
+class WishDescriptionColumn(StrColumn):
+    type_ = WishDescription
+
+
+# pylint: disable-next=abstract-method,too-many-ancestors
+class WishTitleColumn(StrColumn):
+    type_ = WishTitle

--- a/src/wish/controllers.py
+++ b/src/wish/controllers.py
@@ -16,12 +16,12 @@ from src.wish.models import WishBooking
 
 
 if TYPE_CHECKING:
-    from pydantic import PositiveInt
     from sqlalchemy.ext.asyncio import AsyncSession
+    from wlss.shared.types import Id
 
 
 async def create_wish(
-    account_id: PositiveInt,
+    account_id: Id,
     new_wish: schemas.NewWish,
     current_account: Account,
     session: AsyncSession,
@@ -33,8 +33,8 @@ async def create_wish(
 
 
 async def update_wish(
-    account_id: PositiveInt,
-    wish_id: PositiveInt,
+    account_id: Id,
+    wish_id: Id,
     wish_update: schemas.WishUpdate,
     current_account: Account,
     session: AsyncSession,
@@ -47,8 +47,8 @@ async def update_wish(
 
 
 async def delete_wish(
-    account_id: PositiveInt,
-    wish_id: PositiveInt,
+    account_id: Id,
+    wish_id: Id,
     current_account: Account,
     session: AsyncSession,
 ) -> None:
@@ -59,7 +59,7 @@ async def delete_wish(
 
 
 async def get_account_wishes(
-    account_id: PositiveInt,
+    account_id: Id,
     current_account: Account,
     session: AsyncSession,
 ) -> schemas.Wishes:
@@ -74,7 +74,7 @@ async def get_account_wishes(
 
 
 async def create_wish_booking(
-    account_id: PositiveInt,
+    account_id: Id,
     new_wish_booking: schemas.NewWishBooking,
     current_account: Account,
     session: AsyncSession,
@@ -92,8 +92,8 @@ async def create_wish_booking(
 
 
 async def get_wish_bookings(
-    account_id: PositiveInt,
-    wish_ids: list[PositiveInt],
+    account_id: Id,
+    wish_ids: list[Id],
     current_account: Account,
     session: AsyncSession,
 ) -> schemas.WishBookings:
@@ -104,7 +104,7 @@ async def get_wish_bookings(
 
 
 async def delete_wish_booking(
-    booking_id: PositiveInt,
+    booking_id: Id,
     current_account: Account,
     session: AsyncSession,
 ) -> None:

--- a/src/wish/fields.py
+++ b/src/wish/fields.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import PlainSerializer, PlainValidator, WithJsonSchema
+from pydantic.json_schema import GenerateJsonSchema
+from pydantic_core.core_schema import str_schema
+from wlss.wish.types import WishDescription, WishTitle
+
+
+WishDescriptionField = Annotated[
+    WishDescription,
+    PlainValidator(WishDescription),
+    PlainSerializer(lambda v: v.value, return_type=str),
+    WithJsonSchema(GenerateJsonSchema().generate(
+        str_schema(
+            max_length=WishDescription.LENGTH_MAX.value,
+            min_length=WishDescription.LENGTH_MIN.value,
+            pattern=WishDescription.REGEXP.pattern,
+        ),
+    )),
+]
+
+
+WishTitleField = Annotated[
+    WishTitle,
+    PlainValidator(WishTitle),
+    PlainSerializer(lambda v: v.value, return_type=str),
+    WithJsonSchema(GenerateJsonSchema().generate(
+        str_schema(
+            max_length=WishTitle.LENGTH_MAX.value,
+            min_length=WishTitle.LENGTH_MIN.value,
+            pattern=WishTitle.REGEXP.pattern,
+        ),
+    )),
+]

--- a/src/wish/models.py
+++ b/src/wish/models.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
 import typing
-from datetime import datetime
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import DateTime, delete, ForeignKey, Integer, select, String, UniqueConstraint, update
+from sqlalchemy import delete, ForeignKey, select, UniqueConstraint, update
 from sqlalchemy.orm import Mapped, mapped_column
+from wlss.shared.types import Id, UtcDatetime
+from wlss.wish.types import WishDescription, WishTitle
 
 from src.file.models import File
+from src.shared.columns import IdColumn, UtcDatetimeColumn
 from src.shared.database import Base
 from src.shared.datetime import utcnow
+from src.wish.columns import WishDescriptionColumn, WishTitleColumn
 
 
 if TYPE_CHECKING:
@@ -25,16 +28,14 @@ class Wish(Base):
 
     __tablename__ = "wish"
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)  # noqa: A003
+    id: Mapped[Id] = mapped_column(IdColumn, primary_key=True)  # noqa: A003
 
-    account_id: Mapped[int] = mapped_column(ForeignKey("account.id"), nullable=False)
+    account_id: Mapped[Id] = mapped_column(ForeignKey("account.id"), nullable=False)
     avatar_id: Mapped[UUID | None] = mapped_column(ForeignKey("file.id"), unique=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow, nullable=False)
-    description: Mapped[str | None] = mapped_column(String(10_000), nullable=False)
-    title: Mapped[str] = mapped_column(String(100), nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utcnow, nullable=False, onupdate=utcnow,
-    )
+    created_at: Mapped[UtcDatetime] = mapped_column(UtcDatetimeColumn, default=utcnow, nullable=False)
+    description: Mapped[WishDescription | None] = mapped_column(WishDescriptionColumn, nullable=False)
+    title: Mapped[WishTitle] = mapped_column(WishTitleColumn, nullable=False)
+    updated_at: Mapped[UtcDatetime] = mapped_column(UtcDatetimeColumn, default=utcnow, nullable=False, onupdate=utcnow)
 
     async def update(self: Self, session: AsyncSession, wish_update: WishUpdate) -> Wish:
         query = (
@@ -64,7 +65,7 @@ class Wish(Base):
         await session.execute(query)
         await session.flush()
 
-    async def create_booking(self: Self, session: AsyncSession, account_id: int) -> WishBooking:
+    async def create_booking(self: Self, session: AsyncSession, account_id: Id) -> WishBooking:
         wish_booking = WishBooking(account_id=account_id, wish_id=self.id)
         session.add(wish_booking)
         await session.flush()
@@ -75,21 +76,19 @@ class WishBooking(Base):
 
     __tablename__ = "wish_booking"
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)  # noqa: A003
+    id: Mapped[Id] = mapped_column(IdColumn, primary_key=True)  # noqa: A003
 
-    account_id: Mapped[int] = mapped_column(ForeignKey("account.id"), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow, nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utcnow, nullable=False, onupdate=utcnow,
-    )
-    wish_id: Mapped[int] = mapped_column(ForeignKey("wish.id"), nullable=False)
+    account_id: Mapped[Id] = mapped_column(ForeignKey("account.id"), nullable=False)
+    created_at: Mapped[UtcDatetime] = mapped_column(UtcDatetimeColumn, default=utcnow, nullable=False)
+    updated_at: Mapped[UtcDatetime] = mapped_column(UtcDatetimeColumn, default=utcnow, nullable=False, onupdate=utcnow)
+    wish_id: Mapped[Id] = mapped_column(ForeignKey("wish.id"), nullable=False)
 
     __table_args__ = (
         UniqueConstraint("account_id", "wish_id", name="account_id__wish_id__unique_together"),
     )
 
     @classmethod
-    async def find_by_wish_ids(cls: type[WishBooking], session: AsyncSession, wish_ids: list[int]) -> list[WishBooking]:
+    async def find_by_wish_ids(cls: type[WishBooking], session: AsyncSession, wish_ids: list[Id]) -> list[WishBooking]:
         query = select(WishBooking).where(WishBooking.wish_id.in_(wish_ids))
         rows = (await session.execute(query)).all()
         return [typing.cast(WishBooking, row.WishBooking) for row in rows]

--- a/src/wish/routes.py
+++ b/src/wish/routes.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, Path, Query, status
-from pydantic import PositiveInt
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.account.models import Account
 from src.auth.dependencies import get_account_from_access_token
 from src.shared import swagger as shared_swagger
 from src.shared.database import get_session
+from src.shared.fields import IdField
 from src.wish import controllers, schemas
 
 
@@ -44,7 +44,7 @@ router = APIRouter(tags=["wish"])
     summary="Create a wish.",
 )
 async def create_wish(
-    account_id: Annotated[PositiveInt, Path(example=42)],
+    account_id: Annotated[IdField, Path(example=42)],
     new_wish: Annotated[
         schemas.NewWish,
         Body(
@@ -89,8 +89,8 @@ async def create_wish(
     summary="Update particular wish.",
 )
 async def update_wish(
-    account_id: Annotated[PositiveInt, Path(example=42)],
-    wish_id: Annotated[PositiveInt, Path(example=17)],
+    account_id: Annotated[IdField, Path(example=42)],
+    wish_id: Annotated[IdField, Path(example=17)],
     wish_update: Annotated[
         schemas.WishUpdate,
         Body(
@@ -123,8 +123,8 @@ async def update_wish(
     summary="Delete particular wish.",
 )
 async def delete_wish(
-    account_id: Annotated[PositiveInt, Path(example=42)],
-    wish_id: Annotated[PositiveInt, Path(example=17)],
+    account_id: Annotated[IdField, Path(example=42)],
+    wish_id: Annotated[IdField, Path(example=17)],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
 ) -> None:
@@ -171,7 +171,7 @@ async def delete_wish(
     summary="Get account wishes.",
 )
 async def get_account_wishes(
-    account_id: Annotated[PositiveInt, Path(example=42)],
+    account_id: Annotated[IdField, Path(example=42)],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
 ) -> schemas.Wishes:
@@ -203,7 +203,7 @@ async def get_account_wishes(
     summary="Book particular wish.",
 )
 async def create_wish_booking(
-    account_id: Annotated[PositiveInt, Path(example=42)],
+    account_id: Annotated[IdField, Path(example=42)],
     new_wish_booking: Annotated[
         schemas.NewWishBooking,
         Body(
@@ -252,8 +252,8 @@ async def create_wish_booking(
     summary="Get wish bookings.",
 )
 async def get_wish_bookings(
-    account_id: Annotated[PositiveInt, Path(example=42)],
-    wish_ids: Annotated[list[PositiveInt], Query(example=[42, 18], alias="wish_id")],
+    account_id: Annotated[IdField, Path(example=42)],
+    wish_ids: Annotated[list[IdField], Query(example=[42, 18], alias="wish_id")],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
 ) -> schemas.WishBookings:
@@ -277,7 +277,7 @@ async def get_wish_bookings(
     summary="Delete wish booking.",
 )
 async def delete_wish_booking(
-    booking_id: Annotated[PositiveInt, Path(example=42)],
+    booking_id: Annotated[IdField, Path(example=42)],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
 ) -> None:

--- a/src/wish/schemas.py
+++ b/src/wish/schemas.py
@@ -1,21 +1,18 @@
 from __future__ import annotations
 
-from datetime import datetime
-from uuid import UUID
-
-from pydantic import PositiveInt
-
+from src.shared.fields import IdField, UtcDatetimeField, UuidField
 from src.shared.schemas import Schema
+from src.wish.fields import WishDescriptionField, WishTitleField
 
 
 class Wish(Schema):
-    id: PositiveInt  # noqa: A003
+    id: IdField  # noqa: A003
 
-    account_id: PositiveInt
-    avatar_id: UUID | None = None
-    created_at: datetime
-    description: str
-    title: str
+    account_id: IdField
+    avatar_id: UuidField | None = None
+    created_at: UtcDatetimeField
+    description: WishDescriptionField
+    title: WishTitleField
 
 
 class Wishes(Schema):
@@ -23,21 +20,21 @@ class Wishes(Schema):
 
 
 class NewWish(Schema):
-    avatar_id: UUID | None = None
-    description: str
-    title: str
+    avatar_id: UuidField | None = None
+    description: WishDescriptionField
+    title: WishTitleField
 
 
 class WishUpdate(Schema):
-    avatar_id: UUID | None = None
-    description: str
-    title: str
+    avatar_id: UuidField | None = None
+    description: WishDescriptionField
+    title: WishTitleField
 
 
 class WishBooking(Schema):
-    account_id: PositiveInt
-    created_at: datetime
-    wish_id: PositiveInt
+    account_id: IdField
+    created_at: UtcDatetimeField
+    wish_id: IdField
 
 
 class WishBookings(Schema):
@@ -45,5 +42,5 @@ class WishBookings(Schema):
 
 
 class NewWishBooking(Schema):
-    account_id: PositiveInt
-    wish_id: PositiveInt
+    account_id: IdField
+    wish_id: IdField

--- a/tests/test_account/conftest.py
+++ b/tests/test_account/conftest.py
@@ -5,6 +5,8 @@ from uuid import UUID
 
 import jwt
 import pytest
+from wlss.account.types import AccountEmail, AccountLogin
+from wlss.shared.types import Id
 
 from src.account.models import Account, PasswordHash
 from src.auth.models import Session
@@ -17,12 +19,12 @@ from tests.utils import bcrypt as bcrypt_cached
 async def db_with_one_account(db_empty):
     session = db_empty
 
-    account = Account(id=1, email="john.doe@mail.com", login="john_doe")
+    account = Account(id=Id(1), email=AccountEmail("john.doe@mail.com"), login=AccountLogin("john_doe"))
     session.add(account)
     await session.flush()
 
     hash_value = bcrypt_cached.hashpw(b"qwerty123", salt=b"$2b$12$K4wmY3GEMQFoMvpuFK.GMu")
-    password_hash = PasswordHash(account_id=account.id, value=hash_value)
+    password_hash = PasswordHash(account_id=Id(1), value=hash_value)
     session.add(password_hash)
     await session.flush()
 
@@ -34,7 +36,7 @@ async def db_with_one_account(db_empty):
 async def db_with_one_account_and_one_session(db_with_one_account):  # pylint: disable=redefined-outer-name
     session = db_with_one_account
 
-    auth_session = Session(id=UUID("b9dd3a32-aee8-4a6b-a519-def9ca30c9ec"), account_id=1)
+    auth_session = Session(id=UUID("b9dd3a32-aee8-4a6b-a519-def9ca30c9ec"), account_id=Id(1))
     session.add(auth_session)
     await session.flush()
 

--- a/tests/test_account/test_create_account.py
+++ b/tests/test_account/test_create_account.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import bcrypt
-import dirty_equals
 import pytest
 from sqlalchemy import select
+from wlss.account.types import AccountEmail, AccountLogin
+from wlss.profile.types import ProfileDescription, ProfileName
 
 from src.account.models import Account, PasswordHash
 from src.profile.models import Profile
 from src.shared.database import Base
+from tests.utils.dirty_equals import IsId, IsIdSerialized, IsUtcDatetime, IsUtcDatetimeSerialized
 from tests.utils.mocks.models import __eq__
 
 
@@ -34,13 +36,13 @@ async def test_create_account_returns_201_with_correct_body(f):
     assert result.status_code == 201
     assert result.json() == {
         "account": {
-            "id": dirty_equals.IsPositiveInt,
-            "created_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
+            "id": IsIdSerialized,
+            "created_at": IsUtcDatetimeSerialized,
             "email": "john.doe@mail.com",
             "login": "john_doe",
         },
         "profile": {
-            "account_id": dirty_equals.IsPositiveInt,
+            "account_id": IsIdSerialized,
             "avatar_id": None,
             "description": "I'm the best guy for your mocks.",
             "name": "John Doe",
@@ -74,29 +76,29 @@ async def test_create_account_creates_objects_in_db_correctly(f):
         accounts = (await f.db.execute(select(Account))).scalars().all()
         assert accounts == [
             Account(
-                created_at=dirty_equals.IsDatetime(enforce_tz=True),
-                email="john.doe@mail.com",
-                id=dirty_equals.IsPositiveInt,
-                login="john_doe",
-                updated_at=dirty_equals.IsDatetime(enforce_tz=True),
+                created_at=IsUtcDatetime,
+                email=AccountEmail("john.doe@mail.com"),
+                id=IsId,
+                login=AccountLogin("john_doe"),
+                updated_at=IsUtcDatetime,
             ),
         ]
         profiles = (await f.db.execute(select(Profile))).scalars().all()
         assert profiles == [
             Profile(
-                account_id=dirty_equals.IsPositiveInt,
+                account_id=IsId,
                 avatar_id=None,
-                description="I'm the best guy for your mocks.",
-                name="John Doe",
-                updated_at=dirty_equals.IsDatetime(enforce_tz=True),
+                description=ProfileDescription("I'm the best guy for your mocks."),
+                name=ProfileName("John Doe"),
+                updated_at=IsUtcDatetime,
             ),
         ]
         password_hashes = (await f.db.execute(select(PasswordHash))).scalars().all()
         assert password_hashes == [
             PasswordHash(
-                account_id=dirty_equals.IsPositiveInt,
-                created_at=dirty_equals.IsDatetime(enforce_tz=True),
-                updated_at=dirty_equals.IsDatetime(enforce_tz=True),
+                account_id=IsId,
+                created_at=IsUtcDatetime,
+                updated_at=IsUtcDatetime,
                 value=b"password-hash",
             ),
         ]

--- a/tests/test_auth/conftest.py
+++ b/tests/test_auth/conftest.py
@@ -5,6 +5,8 @@ from uuid import UUID
 
 import jwt
 import pytest
+from wlss.account.types import AccountEmail, AccountLogin
+from wlss.shared.types import Id
 
 from src.account.models import Account, PasswordHash
 from src.auth.models import Session
@@ -17,12 +19,12 @@ from tests.utils import bcrypt as bcrypt_cached
 async def db_with_one_account(db_empty):
     session = db_empty
 
-    account = Account(id=1, email="john.doe@mail.com", login="john_doe")
+    account = Account(id=Id(1), email=AccountEmail("john.doe@mail.com"), login=AccountLogin("john_doe"))
     session.add(account)
     await session.flush()
 
     hash_value = bcrypt_cached.hashpw(b"qwerty123", salt=b"$2b$12$K4wmY3GEMQFoMvpuFK.GMu")
-    password_hash = PasswordHash(account_id=account.id, value=hash_value)
+    password_hash = PasswordHash(account_id=Id(1), value=hash_value)
     session.add(password_hash)
     await session.flush()
 
@@ -34,7 +36,7 @@ async def db_with_one_account(db_empty):
 async def db_with_one_account_and_one_session(db_with_one_account):  # pylint: disable=redefined-outer-name
     session = db_with_one_account
 
-    auth_session = Session(id=UUID("b9dd3a32-aee8-4a6b-a519-def9ca30c9ec"), account_id=1)
+    auth_session = Session(id=UUID("b9dd3a32-aee8-4a6b-a519-def9ca30c9ec"), account_id=Id(1))
     session.add(auth_session)
     await session.flush()
 
@@ -48,7 +50,7 @@ async def db_with_one_account_and_two_sessions(
 ):  # pylint: disable=redefined-outer-name
     session = db_with_one_account_and_one_session
 
-    auth_session = Session(id=UUID("2ee55d6c-fe71-4ba0-9bbc-df074d365f60"), account_id=1)
+    auth_session = Session(id=UUID("2ee55d6c-fe71-4ba0-9bbc-df074d365f60"), account_id=Id(1))
     session.add(auth_session)
     await session.flush()
 

--- a/tests/test_auth/test_create_session.py
+++ b/tests/test_auth/test_create_session.py
@@ -6,10 +6,12 @@ import dirty_equals
 import jwt
 import pytest
 from sqlalchemy import select
+from wlss.shared.types import Id
 
 from src.auth.models import Session
 from src.config import CONFIG
 from src.shared.database import Base
+from tests.utils.dirty_equals import IsUtcDatetime, IsUtcDatetimeSerialized
 from tests.utils.mocks.models import __eq__
 
 
@@ -32,13 +34,13 @@ async def test_create_session_returns_200_with_correct_response(f):
     access_token = result.json()["tokens"]["access_token"]
     assert jwt.decode(access_token, CONFIG.SECRET_KEY, "HS256") == {
         "account_id": 1,
-        "expires_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
+        "expires_at": IsUtcDatetimeSerialized,
         "session_id": dirty_equals.IsUUID(4),
     }
     refresh_token = result.json()["tokens"]["refresh_token"]
     assert jwt.decode(refresh_token, CONFIG.SECRET_KEY, "HS256") == {
         "account_id": 1,
-        "expires_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
+        "expires_at": IsUtcDatetimeSerialized,
         "session_id": dirty_equals.IsUUID(4),
     }
 
@@ -53,9 +55,9 @@ async def test_create_session_creates_session_in_db_correctly(f):
         assert rows == [
             Session(
                 id=dirty_equals.IsUUID(4),
-                account_id=1,
-                created_at=dirty_equals.IsDatetime(enforce_tz=True),
-                updated_at=dirty_equals.IsDatetime(enforce_tz=True),
+                account_id=Id(1),
+                created_at=IsUtcDatetime,
+                updated_at=IsUtcDatetime,
             ),
         ]
 

--- a/tests/test_auth/test_refresh_tokens.py
+++ b/tests/test_auth/test_refresh_tokens.py
@@ -7,6 +7,8 @@ import jwt
 import pytest
 
 from src.config import CONFIG
+from src.shared.datetime import DATETIME_FORMAT
+from tests.utils.dirty_equals import IsUtcDatetimeSerialized
 
 
 @pytest.mark.anyio
@@ -30,21 +32,21 @@ async def test_refresh_tokens_returns_201_with_correct_response(f):
     access_token_payload = jwt.decode(json["access_token"], CONFIG.SECRET_KEY, "HS256")
     assert access_token_payload == {
         "account_id": 1,
-        "expires_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
+        "expires_at": IsUtcDatetimeSerialized,
         "session_id": "b9dd3a32-aee8-4a6b-a519-def9ca30c9ec",
     }
     refresh_token_payload = jwt.decode(json["refresh_token"], CONFIG.SECRET_KEY, "HS256")
     assert refresh_token_payload == {
         "account_id": 1,
-        "expires_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
+        "expires_at": IsUtcDatetimeSerialized,
         "session_id": "b9dd3a32-aee8-4a6b-a519-def9ca30c9ec",
     }
     access_token_expiration = datetime.strptime(  # noqa: DTZ007
-        access_token_payload["expires_at"], "%Y-%m-%dT%H:%M:%S.%fZ",
+        access_token_payload["expires_at"], DATETIME_FORMAT,
     )
     refresh_token_expiration = datetime.strptime(  # noqa: DTZ007
         refresh_token_payload["expires_at"],
-        "%Y-%m-%dT%H:%M:%S.%fZ",
+        DATETIME_FORMAT,
     )
     assert access_token_expiration < refresh_token_expiration
 

--- a/tests/test_file/conftest.py
+++ b/tests/test_file/conftest.py
@@ -6,6 +6,9 @@ from uuid import UUID
 
 import jwt
 import pytest
+from wlss.account.types import AccountEmail, AccountLogin
+from wlss.file.types import FileSize
+from wlss.shared.types import Id
 
 from src.account.models import Account, PasswordHash
 from src.auth.models import Session
@@ -20,16 +23,16 @@ from tests.utils import bcrypt as bcrypt_cached
 async def db_with_one_account_and_one_session(db_empty):
     session = db_empty
 
-    account = Account(id=1, email="john.doe@mail.com", login="john_doe")
+    account = Account(id=Id(1), email=AccountEmail("john.doe@mail.com"), login=AccountLogin("john_doe"))
     session.add(account)
     await session.flush()
 
     hash_value = bcrypt_cached.hashpw(b"qwerty123", salt=b"$2b$12$K4wmY3GEMQFoMvpuFK.GMu")
-    password_hash = PasswordHash(account_id=account.id, value=hash_value)
+    password_hash = PasswordHash(account_id=Id(1), value=hash_value)
     session.add(password_hash)
     await session.flush()
 
-    auth_session = Session(id=UUID("b9dd3a32-aee8-4a6b-a519-def9ca30c9ec"), account_id=1)
+    auth_session = Session(id=UUID("b9dd3a32-aee8-4a6b-a519-def9ca30c9ec"), account_id=Id(1))
     session.add(auth_session)
     await session.flush()
 
@@ -46,7 +49,7 @@ async def db_with_one_file(db_with_one_account_and_one_session):  # pylint: disa
         extension=Extension.PNG,
         mime_type=MimeType.IMAGE_PNG,
         name="image.png",
-        size=17,
+        size=FileSize(17),
     )
     session.add(file)
     await session.flush()

--- a/tests/test_file/test_create_file.py
+++ b/tests/test_file/test_create_file.py
@@ -7,10 +7,12 @@ from unittest.mock import patch
 import dirty_equals
 import pytest
 from sqlalchemy import select
+from wlss.file.types import FileSize
 
 from src.file.enums import Extension, MimeType
 from src.file.models import File
 from src.shared.database import Base
+from tests.utils.dirty_equals import IsUtcDatetime
 from tests.utils.mocks.models import __eq__
 
 
@@ -55,13 +57,13 @@ async def test_create_file_creates_file_in_db_correctly(f):
         files = (await f.db.execute(select(File))).scalars().all()
         assert files == [
             File(
-                created_at=dirty_equals.IsDatetime(enforce_tz=True),
+                created_at=IsUtcDatetime,
                 id=dirty_equals.IsUUID(4),
                 extension=Extension.PNG,
                 mime_type=MimeType.IMAGE_PNG,
                 name="image.png",
-                size=17,
-                updated_at=dirty_equals.IsDatetime(enforce_tz=True),
+                size=FileSize(17),
+                updated_at=IsUtcDatetime,
             ),
         ]
 

--- a/tests/test_friendship/conftest.py
+++ b/tests/test_friendship/conftest.py
@@ -5,6 +5,9 @@ from uuid import UUID
 
 import jwt
 import pytest
+from wlss.account.types import AccountEmail, AccountLogin
+from wlss.profile.types import ProfileName
+from wlss.shared.types import Id
 
 from src.account.models import Account
 from src.auth.models import Session
@@ -21,14 +24,14 @@ async def db_with_two_accounts(db_empty):
 
     accounts = [
         Account(
-            id=1,
-            email="john.doe@mail.com",
-            login="john_doe",
+            id=Id(1),
+            email=AccountEmail("john.doe@mail.com"),
+            login=AccountLogin("john_doe"),
         ),
         Account(
-            id=2,
-            email="john.smith@mail.com",
-            login="john_smith",
+            id=Id(2),
+            email=AccountEmail("john.smith@mail.com"),
+            login=AccountLogin("john_smith"),
         ),
     ]
     session.add_all(accounts)
@@ -36,23 +39,23 @@ async def db_with_two_accounts(db_empty):
 
     auth_session = Session(
         id=UUID("b9dd3a32-aee8-4a6b-a519-def9ca30c9ec"),
-        account_id=1,
+        account_id=Id(1),
     )
     session.add(auth_session)
     await session.flush()
 
     profiles = [
         Profile(
-            account_id=1,
+            account_id=Id(1),
             avatar_id=None,
             description=None,
-            name="John Doe",
+            name=ProfileName("John Doe"),
         ),
         Profile(
-            account_id=2,
+            account_id=Id(2),
             avatar_id=None,
             description=None,
-            name="John Smith",
+            name=ProfileName("John Smith"),
         ),
     ]
     session.add_all(profiles)
@@ -66,7 +69,7 @@ async def db_with_two_accounts(db_empty):
 async def db_with_one_friendship_request(db_with_two_accounts):  # pylint: disable=redefined-outer-name
     session = db_with_two_accounts
 
-    friendship_request = FriendshipRequest(id=1, receiver_id=2, sender_id=1)
+    friendship_request = FriendshipRequest(id=Id(1), receiver_id=Id(2), sender_id=Id(1))
     session.add(friendship_request)
     await session.flush()
 
@@ -78,7 +81,12 @@ async def db_with_one_friendship_request(db_with_two_accounts):  # pylint: disab
 async def db_with_accepted_friendship_request(db_with_two_accounts):  # pylint: disable=redefined-outer-name
     session = db_with_two_accounts
 
-    friendship_request = FriendshipRequest(id=1, receiver_id=2, sender_id=1, status=FriendshipRequestStatus.ACCEPTED)
+    friendship_request = FriendshipRequest(
+        id=Id(1),
+        receiver_id=Id(2),
+        sender_id=Id(1),
+        status=FriendshipRequestStatus.ACCEPTED,
+    )
     session.add(friendship_request)
     await session.flush()
 
@@ -90,7 +98,7 @@ async def db_with_accepted_friendship_request(db_with_two_accounts):  # pylint: 
 async def db_with_friendship_request_from_another_user(db_with_two_accounts):  # pylint: disable=redefined-outer-name
     session = db_with_two_accounts
 
-    friendship_request = FriendshipRequest(id=1, receiver_id=1, sender_id=2)
+    friendship_request = FriendshipRequest(id=Id(1), receiver_id=Id(1), sender_id=Id(2))
     session.add(friendship_request)
     await session.flush()
 
@@ -105,36 +113,36 @@ async def db_with_three_accounts_and_three_friendship_requests(
     session = db_with_two_accounts
 
     account = Account(
-        id=3,
-        email="john.bloggs@mail.com",
-        login="john_bloggs",
+        id=Id(3),
+        email=AccountEmail("john.bloggs@mail.com"),
+        login=AccountLogin("john_bloggs"),
     )
     session.add(account)
     await session.flush()
 
     profile = Profile(
-        account_id=3,
+        account_id=Id(3),
         avatar_id=None,
         description=None,
-        name="John Bloggs",
+        name=ProfileName("John Bloggs"),
     )
     session.add(profile)
     await session.flush()
 
     friendship_requests = [
         FriendshipRequest(
-            sender_id=1,
-            receiver_id=2,
+            sender_id=Id(1),
+            receiver_id=Id(2),
             status=FriendshipRequestStatus.PENDING,
         ),
         FriendshipRequest(
-            sender_id=2,
-            receiver_id=3,
+            sender_id=Id(2),
+            receiver_id=Id(3),
             status=FriendshipRequestStatus.PENDING,
         ),
         FriendshipRequest(
-            sender_id=3,
-            receiver_id=1,
+            sender_id=Id(3),
+            receiver_id=Id(1),
             status=FriendshipRequestStatus.PENDING,
         ),
     ]
@@ -151,12 +159,12 @@ async def db_with_two_friendships(db_with_two_accounts):  # pylint: disable=rede
 
     friendships = [
         Friendship(
-            account_id=1,
-            friend_id=2,
+            account_id=Id(1),
+            friend_id=Id(2),
         ),
         Friendship(
-            account_id=2,
-            friend_id=1,
+            account_id=Id(2),
+            friend_id=Id(1),
         ),
     ]
     session.add_all(friendships)

--- a/tests/test_friendship/test_accept_friendship_request.py
+++ b/tests/test_friendship/test_accept_friendship_request.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import dirty_equals
 import pytest
 from sqlalchemy import select
+from wlss.shared.types import Id
 
 from src.friendship.enums import FriendshipRequestStatus
 from src.friendship.models import Friendship, FriendshipRequest
 from src.shared.database import Base
+from tests.utils.dirty_equals import IsUtcDatetime, IsUtcDatetimeSerialized
 from tests.utils.mocks.models import __eq__
 
 
@@ -25,12 +26,12 @@ async def test_accept_friendship_request_returns_201_with_correct_response(f):
         "friendships": [
             {
                 "account_id": 1,
-                "created_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
+                "created_at": IsUtcDatetimeSerialized,
                 "friend_id": 2,
             },
             {
                 "account_id": 2,
-                "created_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
+                "created_at": IsUtcDatetimeSerialized,
                 "friend_id": 1,
             },
         ],
@@ -49,27 +50,27 @@ async def test_accept_friendship_request_creates_objects_in_db_correctly(f):
         friendship_requests = (await f.db.execute(select(FriendshipRequest))).scalars().all()
         assert friendship_requests == [
             FriendshipRequest(
-                id=1,
-                created_at=dirty_equals.IsDatetime(enforce_tz=True),
-                receiver_id=2,
-                sender_id=1,
+                id=Id(1),
+                created_at=IsUtcDatetime,
+                receiver_id=Id(2),
+                sender_id=Id(1),
                 status=FriendshipRequestStatus.ACCEPTED,
-                updated_at=dirty_equals.IsDatetime(enforce_tz=True),
+                updated_at=IsUtcDatetime,
             ),
         ]
         friendships = (await f.db.execute(select(Friendship).order_by(Friendship.account_id))).scalars().all()
         assert friendships == [
             Friendship(
-                account_id=1,
-                created_at=dirty_equals.IsDatetime(enforce_tz=True),
-                friend_id=2,
-                updated_at=dirty_equals.IsDatetime(enforce_tz=True),
+                account_id=Id(1),
+                created_at=IsUtcDatetime,
+                friend_id=Id(2),
+                updated_at=IsUtcDatetime,
             ),
             Friendship(
-                account_id=2,
-                created_at=dirty_equals.IsDatetime(enforce_tz=True),
-                friend_id=1,
-                updated_at=dirty_equals.IsDatetime(enforce_tz=True),
+                account_id=Id(2),
+                created_at=IsUtcDatetime,
+                friend_id=Id(1),
+                updated_at=IsUtcDatetime,
             ),
         ]
 

--- a/tests/test_friendship/test_create_friendship_request.py
+++ b/tests/test_friendship/test_create_friendship_request.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import dirty_equals
 import pytest
 from sqlalchemy import select
+from wlss.shared.types import Id
 
 from src.friendship.enums import FriendshipRequestStatus
 from src.friendship.models import FriendshipRequest
 from src.shared.database import Base
+from tests.utils.dirty_equals import IsId, IsUtcDatetime, IsUtcDatetimeSerialized
 from tests.utils.mocks.models import __eq__
 
 
@@ -24,7 +25,7 @@ async def test_create_friendship_request_returns_201_with_correct_response(f):
     assert result.status_code == 201
     assert result.json() == {
         "id": 10000,
-        "created_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
+        "created_at": IsUtcDatetimeSerialized,
         "receiver_id": 2,
         "sender_id": 1,
         "status": "PENDING",
@@ -44,12 +45,12 @@ async def test_create_friendship_request_creates_objects_in_db_correctly(f):
         friendship_requests = (await f.db.execute(select(FriendshipRequest))).scalars().all()
         assert friendship_requests == [
             FriendshipRequest(
-                id=dirty_equals.IsInt,
-                created_at=dirty_equals.IsDatetime(enforce_tz=True),
-                receiver_id=2,
-                sender_id=1,
+                id=IsId,
+                created_at=IsUtcDatetime,
+                receiver_id=Id(2),
+                sender_id=Id(1),
                 status=FriendshipRequestStatus.PENDING,
-                updated_at=dirty_equals.IsDatetime(enforce_tz=True),
+                updated_at=IsUtcDatetime,
             ),
         ]
 

--- a/tests/test_friendship/test_get_friends.py
+++ b/tests/test_friendship/test_get_friends.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import dirty_equals
 import pytest
+
+from tests.utils.dirty_equals import IsUtcDatetimeSerialized
 
 
 @pytest.mark.anyio
@@ -23,7 +24,7 @@ async def test_get_friends_returns_200_with_correct_response(f):
                     "name": "John Smith",
                 },
                 "friendship": {
-                    "created_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
+                    "created_at": IsUtcDatetimeSerialized,
                 },
             },
         ],

--- a/tests/test_friendship/test_get_friendship_requests.py
+++ b/tests/test_friendship/test_get_friendship_requests.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import dirty_equals
 import pytest
 
+from tests.utils.dirty_equals import IsUtcDatetimeSerialized
+
 
 @pytest.mark.anyio
 @pytest.mark.fixtures({
@@ -21,14 +23,14 @@ async def test_get_friendship_requests_returns_200_with_correct_response(f):
         "requests": [
             {
                 "id": dirty_equals.IsInt,
-                "created_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
+                "created_at": IsUtcDatetimeSerialized,
                 "receiver_id": 2,
                 "sender_id": 1,
                 "status": "PENDING",
             },
             {
                 "id": dirty_equals.IsInt,
-                "created_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
+                "created_at": IsUtcDatetimeSerialized,
                 "receiver_id": 1,
                 "sender_id": 3,
                 "status": "PENDING",

--- a/tests/test_friendship/test_reject_friendship_request.py
+++ b/tests/test_friendship/test_reject_friendship_request.py
@@ -5,10 +5,12 @@ from unittest.mock import patch
 import dirty_equals
 import pytest
 from sqlalchemy import select
+from wlss.shared.types import Id
 
 from src.friendship.enums import FriendshipRequestStatus
 from src.friendship.models import FriendshipRequest
 from src.shared.database import Base
+from tests.utils.dirty_equals import IsUtcDatetime, IsUtcDatetimeSerialized
 from tests.utils.mocks.models import __eq__
 
 
@@ -23,7 +25,7 @@ async def test_reject_friendship_request_returns_200_with_correct_response(f):
     assert result.status_code == 200
     assert result.json() == {
         "id": dirty_equals.IsInt,
-        "created_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
+        "created_at": IsUtcDatetimeSerialized,
         "receiver_id": 2,
         "sender_id": 1,
         "status": "REJECTED",
@@ -42,12 +44,12 @@ async def test_reject_friendship_request_updates_objects_in_db_correctly(f):
         friendship_requests = (await f.db.execute(select(FriendshipRequest))).scalars().all()
         assert friendship_requests == [
             FriendshipRequest(
-                id=1,
-                created_at=dirty_equals.IsDatetime(enforce_tz=True),
-                sender_id=1,
-                receiver_id=2,
+                id=Id(1),
+                created_at=IsUtcDatetime,
+                sender_id=Id(1),
+                receiver_id=Id(2),
                 status=FriendshipRequestStatus.REJECTED,
-                updated_at=dirty_equals.IsDatetime(enforce_tz=True),
+                updated_at=IsUtcDatetime,
             ),
         ]
 

--- a/tests/test_profile/conftest.py
+++ b/tests/test_profile/conftest.py
@@ -5,6 +5,10 @@ from uuid import UUID
 
 import jwt
 import pytest
+from wlss.account.types import AccountEmail, AccountLogin
+from wlss.file.types import FileSize
+from wlss.profile.types import ProfileName
+from wlss.shared.types import Id
 
 from src.account.models import Account
 from src.auth.models import Session
@@ -20,25 +24,25 @@ async def db_with_one_profile_and_one_file(db_empty):
     session = db_empty
 
     account = Account(
-        id=1,
-        email="john.doe@mail.com",
-        login="john_doe",
+        id=Id(1),
+        email=AccountEmail("john.doe@mail.com"),
+        login=AccountLogin("john_doe"),
     )
     session.add(account)
     await session.flush()
 
     auth_session = Session(
         id=UUID("b9dd3a32-aee8-4a6b-a519-def9ca30c9ec"),
-        account_id=1,
+        account_id=Id(1),
     )
     session.add(auth_session)
     await session.flush()
 
     profile = Profile(
-        account_id=1,
+        account_id=Id(1),
         avatar_id=None,
         description=None,
-        name="John Doe",
+        name=ProfileName("John Doe"),
     )
     session.add(profile)
     await session.flush()
@@ -48,7 +52,7 @@ async def db_with_one_profile_and_one_file(db_empty):
         extension=Extension.PNG,
         mime_type=MimeType.IMAGE_PNG,
         name="image.png",
-        size=42,
+        size=FileSize(42),
     )
     session.add(file)
     await session.flush()

--- a/tests/test_profile/test_update_profile.py
+++ b/tests/test_profile/test_update_profile.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from unittest.mock import patch
 from uuid import UUID
 
-import dirty_equals
 import pytest
 from sqlalchemy import select
+from wlss.profile.types import ProfileDescription, ProfileName
+from wlss.shared.types import Id
 
 from src.profile.models import Profile
 from src.shared.database import Base
+from tests.utils.dirty_equals import IsUtcDatetime
 from tests.utils.mocks.models import __eq__
 
 
@@ -51,10 +53,10 @@ async def test_update_profile_updates_profile_in_db_correctly(f):
         profiles = (await f.db.execute(select(Profile))).scalars().all()
         assert profiles == [
             Profile(
-                account_id=1,
+                account_id=Id(1),
                 avatar_id=UUID("2b41c87b-6f06-438b-9933-2a1568cc593b"),
-                description="Updated description.",
-                name="Updated name.",
-                updated_at=dirty_equals.IsDatetime(enforce_tz=True),
+                description=ProfileDescription("Updated description."),
+                name=ProfileName("Updated name."),
+                updated_at=IsUtcDatetime,
             ),
         ]

--- a/tests/test_wish/conftest.py
+++ b/tests/test_wish/conftest.py
@@ -5,6 +5,10 @@ from uuid import UUID
 
 import jwt
 import pytest
+from wlss.account.types import AccountEmail, AccountLogin
+from wlss.file.types import FileSize
+from wlss.shared.types import Id
+from wlss.wish.types import WishDescription, WishTitle
 
 from src.account.models import Account, PasswordHash
 from src.auth.models import Session
@@ -21,7 +25,7 @@ from tests.utils import bcrypt as bcrypt_cached
 async def db_with_one_account_and_one_file(db_empty):
     session = db_empty
 
-    account = Account(id=1, email="john.doe@mail.com", login="john_doe")
+    account = Account(id=Id(1), email=AccountEmail("john.doe@mail.com"), login=AccountLogin("john_doe"))
     session.add(account)
     await session.flush()
 
@@ -30,7 +34,7 @@ async def db_with_one_account_and_one_file(db_empty):
     session.add(password_hash)
     await session.flush()
 
-    auth_session = Session(id=UUID("b9dd3a32-aee8-4a6b-a519-def9ca30c9ec"), account_id=1)
+    auth_session = Session(id=UUID("b9dd3a32-aee8-4a6b-a519-def9ca30c9ec"), account_id=Id(1))
     session.add(auth_session)
     await session.flush()
 
@@ -39,7 +43,7 @@ async def db_with_one_account_and_one_file(db_empty):
         extension=Extension.PNG,
         mime_type=MimeType.IMAGE_PNG,
         name="image.png",
-        size=17,
+        size=FileSize(17),
     )
     session.add(file)
     await session.flush()
@@ -52,11 +56,11 @@ async def db_with_one_account_and_one_file(db_empty):
 async def db_with_one_wish(db_with_one_account_and_one_file):  # pylint: disable=redefined-outer-name
     session = db_with_one_account_and_one_file
     wish = Wish(
-        id=1,
-        account_id=1,
+        id=Id(1),
+        account_id=Id(1),
         avatar_id=UUID("0b928aaa-521f-47ec-8be5-396650e2a187"),
-        description="I'm gonna take my horse to the old town road.",
-        title="Horse",
+        description=WishDescription("I'm gonna take my horse to the old town road."),
+        title=WishTitle("Horse"),
     )
     session.add(wish)
     await session.flush()
@@ -68,11 +72,11 @@ async def db_with_one_wish(db_with_one_account_and_one_file):  # pylint: disable
 async def db_with_one_wish_without_avatar(db_with_one_account_and_one_file):  # pylint: disable=redefined-outer-name
     session = db_with_one_account_and_one_file
     wish = Wish(
-        id=1,
-        account_id=1,
+        id=Id(1),
+        account_id=Id(1),
         avatar_id=None,
-        description="I'm gonna take my horse to the old town road.",
-        title="Horse",
+        description=WishDescription("I'm gonna take my horse to the old town road."),
+        title=WishTitle("Horse"),
     )
     session.add(wish)
     await session.flush()
@@ -89,7 +93,7 @@ async def db_with_two_files_and_one_wish(db_with_one_wish):  # pylint: disable=r
         extension=Extension.PNG,
         mime_type=MimeType.IMAGE_PNG,
         name="new_image.png",
-        size=17,
+        size=FileSize(17),
     )
     session.add(file)
     await session.flush()
@@ -102,12 +106,12 @@ async def db_with_two_files_and_one_wish(db_with_one_wish):  # pylint: disable=r
 async def db_with_two_accounts_and_one_file(db_with_one_account_and_one_file):  # pylint: disable=redefined-outer-name
     session = db_with_one_account_and_one_file
 
-    account = Account(id=2, email="john.smith@mail.com", login="john_smith")
+    account = Account(id=Id(2), email=AccountEmail("john.smith@mail.com"), login=AccountLogin("john_smith"))
     session.add(account)
     await session.flush()
 
     hash_value = bcrypt_cached.hashpw(b"qwerty123", salt=b"$2b$12$K4wmY3GEMQFoMvpuFK.GMu")
-    password_hash = PasswordHash(account_id=account.id, value=hash_value)
+    password_hash = PasswordHash(account_id=Id(2), value=hash_value)
     session.add(password_hash)
     await session.flush()
 
@@ -119,12 +123,12 @@ async def db_with_two_accounts_and_one_file(db_with_one_account_and_one_file):  
 async def db_with_two_accounts_and_one_wish(db_with_one_wish):  # pylint: disable=redefined-outer-name
     session = db_with_one_wish
 
-    account = Account(id=2, email="john.smith@mail.com", login="john_smith")
+    account = Account(id=Id(2), email=AccountEmail("john.smith@mail.com"), login=AccountLogin("john_smith"))
     session.add(account)
     await session.flush()
 
     hash_value = bcrypt_cached.hashpw(b"qwerty123", salt=b"$2b$12$K4wmY3GEMQFoMvpuFK.GMu")
-    password_hash = PasswordHash(account_id=account.id, value=hash_value)
+    password_hash = PasswordHash(account_id=Id(2), value=hash_value)
     session.add(password_hash)
     await session.flush()
 
@@ -140,23 +144,23 @@ async def db_with_two_friend_accounts_and_one_wish(  # pylint: disable=redefined
 
     friendships = [
         Friendship(
-            account_id=1,
-            friend_id=2,
+            account_id=Id(1),
+            friend_id=Id(2),
         ),
         Friendship(
-            account_id=2,
-            friend_id=1,
+            account_id=Id(2),
+            friend_id=Id(1),
         ),
     ]
     session.add_all(friendships)
     await session.flush()
 
     wish = Wish(
-        id=1,
-        account_id=2,
+        id=Id(1),
+        account_id=Id(2),
         avatar_id=UUID("0b928aaa-521f-47ec-8be5-396650e2a187"),
-        description="I'm gonna take my horse to the old town road.",
-        title="Horse",
+        description=WishDescription("I'm gonna take my horse to the old town road."),
+        title=WishTitle("Horse"),
     )
     session.add(wish)
     await session.flush()
@@ -171,7 +175,7 @@ async def db_with_two_friend_accounts_and_one_wish_booking(  # pylint: disable=r
 ):
     session = db_with_two_friend_accounts_and_one_wish
 
-    wish_booking = WishBooking(id=1, account_id=1, wish_id=1)
+    wish_booking = WishBooking(id=Id(1), account_id=Id(1), wish_id=Id(1))
     session.add(wish_booking)
     await session.flush()
 
@@ -190,17 +194,17 @@ async def db_with_two_accounts_and_two_wishes(  # pylint: disable=redefined-oute
         extension=Extension.PNG,
         mime_type=MimeType.IMAGE_PNG,
         name="new_image.png",
-        size=17,
+        size=FileSize(17),
     )
     session.add(file)
     await session.flush()
 
     wish = Wish(
-        id=2,
-        account_id=1,
+        id=Id(2),
+        account_id=Id(1),
         avatar_id=UUID("4b94605b-f5e1-40b1-b9fc-c635c9529e3e"),
-        description="I need some sleep. Time to put the old horse down.",
-        title="Sleep",
+        description=WishDescription("I need some sleep. Time to put the old horse down."),
+        title=WishTitle("Sleep"),
     )
     session.add(wish)
     await session.flush()

--- a/tests/test_wish/test_create_wish.py
+++ b/tests/test_wish/test_create_wish.py
@@ -6,9 +6,12 @@ from uuid import UUID
 import dirty_equals
 import pytest
 from sqlalchemy import select
+from wlss.shared.types import Id
+from wlss.wish.types import WishDescription, WishTitle
 
 from src.shared.database import Base
 from src.wish.models import Wish
+from tests.utils.dirty_equals import IsId, IsUtcDatetime, IsUtcDatetimeSerialized
 from tests.utils.mocks.models import __eq__
 
 
@@ -30,7 +33,7 @@ async def test_create_wish_returns_201_with_correct_response(f):
         "id": dirty_equals.IsInt,
         "account_id": 1,
         "avatar_id": "0b928aaa-521f-47ec-8be5-396650e2a187",
-        "created_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
+        "created_at": IsUtcDatetimeSerialized,
         "description": "I'm gonna take my horse to the old town road.",
         "title": "Horse",
     }
@@ -53,13 +56,13 @@ async def test_create_wish_creates_objects_in_db_correctly(f):
         wishes = (await f.db.execute(select(Wish))).scalars().all()
         assert wishes == [
             Wish(
-                id=dirty_equals.IsInt,
-                account_id=1,
+                id=IsId,
+                account_id=Id(1),
                 avatar_id=UUID("0b928aaa-521f-47ec-8be5-396650e2a187"),
-                created_at=dirty_equals.IsDatetime(enforce_tz=True),
-                description="I'm gonna take my horse to the old town road.",
-                title="Horse",
-                updated_at=dirty_equals.IsDatetime(enforce_tz=True),
+                created_at=IsUtcDatetime,
+                description=WishDescription("I'm gonna take my horse to the old town road."),
+                title=WishTitle("Horse"),
+                updated_at=IsUtcDatetime,
             ),
         ]
 

--- a/tests/test_wish/test_create_wish_booking.py
+++ b/tests/test_wish/test_create_wish_booking.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-import dirty_equals
 import pytest
 from sqlalchemy import select
+from wlss.shared.types import Id
 
 from src.shared.database import Base
 from src.wish.models import WishBooking
+from tests.utils.dirty_equals import IsId, IsUtcDatetime, IsUtcDatetimeSerialized
 from tests.utils.mocks.models import __eq__
 
 
@@ -27,7 +28,7 @@ async def test_create_wish_booking_returns_201_with_correct_response(f):
     assert result.status_code == 201
     assert result.json() == {
         "account_id": 1,
-        "created_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
+        "created_at": IsUtcDatetimeSerialized,
         "wish_id": 1,
     }
 
@@ -49,11 +50,11 @@ async def test_create_wish_booking_creates_objects_in_db_correctly(f):
         wish_bookings = (await f.db.execute(select(WishBooking))).scalars().all()
         assert wish_bookings == [
             WishBooking(
-                id=dirty_equals.IsPositiveInt,
-                account_id=1,
-                created_at=dirty_equals.IsDatetime(enforce_tz=True),
-                updated_at=dirty_equals.IsDatetime(enforce_tz=True),
-                wish_id=1,
+                id=IsId,
+                account_id=Id(1),
+                created_at=IsUtcDatetime,
+                updated_at=IsUtcDatetime,
+                wish_id=Id(1),
             ),
         ]
 

--- a/tests/test_wish/test_get_account_wishes.py
+++ b/tests/test_wish/test_get_account_wishes.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import dirty_equals
 import pytest
+
+from tests.utils.dirty_equals import IsUtcDatetimeSerialized
 
 
 @pytest.mark.anyio
@@ -19,7 +20,7 @@ async def test_get_account_wishes_returns_200_with_correct_response(f):
                 "id": 1,
                 "account_id": 1,
                 "avatar_id": "0b928aaa-521f-47ec-8be5-396650e2a187",
-                "created_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
+                "created_at": IsUtcDatetimeSerialized,
                 "description": "I'm gonna take my horse to the old town road.",
                 "title": "Horse",
             },
@@ -27,7 +28,7 @@ async def test_get_account_wishes_returns_200_with_correct_response(f):
                 "id": 2,
                 "account_id": 1,
                 "avatar_id": "4b94605b-f5e1-40b1-b9fc-c635c9529e3e",
-                "created_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
+                "created_at": IsUtcDatetimeSerialized,
                 "description": "I need some sleep. Time to put the old horse down.",
                 "title": "Sleep",
             },

--- a/tests/test_wish/test_get_wish_bookings.py
+++ b/tests/test_wish/test_get_wish_bookings.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import dirty_equals
 import pytest
+
+from tests.utils.dirty_equals import IsUtcDatetimeSerialized
 
 
 @pytest.mark.anyio
@@ -21,7 +22,7 @@ async def test_get_wish_bookings_returns_200_with_correct_response(f):
         "wish_bookings": [
             {
                 "account_id": 1,
-                "created_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
+                "created_at": IsUtcDatetimeSerialized,
                 "wish_id": 1,
             },
         ],

--- a/tests/test_wish/test_update_wish.py
+++ b/tests/test_wish/test_update_wish.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from unittest.mock import patch
 from uuid import UUID
 
-import dirty_equals
 import pytest
 from sqlalchemy import select
+from wlss.shared.types import Id
+from wlss.wish.types import WishDescription, WishTitle
 
 from src.shared.database import Base
 from src.wish.models import Wish
+from tests.utils.dirty_equals import IsUtcDatetime, IsUtcDatetimeSerialized
 from tests.utils.mocks.models import __eq__
 
 
@@ -30,7 +32,7 @@ async def test_update_wish_returns_200_with_correct_response(f):
         "id": 1,
         "account_id": 1,
         "avatar_id": "4b94605b-f5e1-40b1-b9fc-c635c9529e3e",
-        "created_at": dirty_equals.IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ"),
+        "created_at": IsUtcDatetimeSerialized,
         "description": "I'm gonna take my NEW horse to the old town road.",
         "title": "NEW Horse",
     }
@@ -53,13 +55,13 @@ async def test_update_wish_updates_objects_in_db_correctly(f):
         wishes = (await f.db.execute(select(Wish))).scalars().all()
         assert wishes == [
             Wish(
-                id=1,
-                account_id=1,
+                id=Id(1),
+                account_id=Id(1),
                 avatar_id=UUID("4b94605b-f5e1-40b1-b9fc-c635c9529e3e"),
-                created_at=dirty_equals.IsDatetime(enforce_tz=True),
-                description="I'm gonna take my NEW horse to the old town road.",
-                title="NEW Horse",
-                updated_at=dirty_equals.IsDatetime(enforce_tz=True),
+                created_at=IsUtcDatetime,
+                description=WishDescription("I'm gonna take my NEW horse to the old town road."),
+                title=WishTitle("NEW Horse"),
+                updated_at=IsUtcDatetime,
             ),
         ]
 

--- a/tests/utils/dirty_equals.py
+++ b/tests/utils/dirty_equals.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import wlss.core.exceptions
+from dirty_equals import DirtyEquals
+from wlss.shared.types import Id, UtcDatetime
+
+
+if TYPE_CHECKING:
+    from typing import Self
+
+
+class IsId(DirtyEquals[Id]):
+    def equals(self: Self, other: str) -> bool:
+        return isinstance(other, Id)
+
+
+class IsIdSerialized(DirtyEquals[int]):
+    def equals(self: Self, other: int) -> bool:
+        try:
+            Id(other)
+        except wlss.core.exceptions.ValidationError:
+            return False
+        return True
+
+
+class IsUtcDatetime(DirtyEquals[UtcDatetime]):
+    def equals(self: Self, other: str) -> bool:
+        return isinstance(other, UtcDatetime)
+
+
+class IsUtcDatetimeSerialized(DirtyEquals[str]):
+    def equals(self: Self, other: str) -> bool:
+        try:
+            UtcDatetime(datetime.fromisoformat(other))
+        except wlss.core.exceptions.ValidationError:
+            return False
+        return True


### PR DESCRIPTION
Для доменных примитивов необходимо вместо стандартных типов вроде `str` или `int` создать свои кастомные классы, которые будут порождать объекты, само существование которых, будет подтверждать их валидность.

Например `Email` вместо `str` и `Age` вместо `int`.

Это поможет нам обеспечить надежность соблюдения инвариантов при оперировании понятиями доменной области. Стандартный тип `str` не подходит для описания и хранения эмейла, т.к. может содержать строку произвольного типа. И даже если перед присвоением этой строки мы заранее проверили её на соответствие правилам эмейла, это не означает что в дальнейшем в рантайме она "случайно" не превратится в невалидный эмейл.

Вместо этого, если мы создадим свой класс эмейл и в коде будем использовать что-то вроде 
`email: Email = Email()`, то мы всегда можем быть уверены, что если объект `email` существует, то он валидный.

---

Для реализации этой идеи необходимо создать библиотеку строгих типов - эта библиотека будет разрабатываться в отдельном репозитории: https://github.com/week-password/wlss-backend-lib

Почему мы решили выделить это в отдельную библиотеку а не просто создать package внутри основного репозитория бэкенда? - отчасти потому, что мы планируем добавлять новый сервис - Backend For Frontend - которому тоже скорее свего надо будет оперировать этими доменными объектами-примитивами для соблюдения инвариантов на своей стороне.

После того как основной функционал библиотеки будет готов, в рамках этой задачи необходимо будет внедрить эти типы из библиотеки в текущий репозиторий бэкенда.