### PR TITLE
Изолировать схемы реквестов и респонзов (#193)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -5,6 +5,9 @@ external = [
     "DAR101",
     "DAR201",
 
+    # flake8
+    "E301",
+
     # flake8-rst-docstrings
     "RST214",
     "RST215",
@@ -40,6 +43,11 @@ src = ["src"]
 
 # ignore checks that are raised only when using FastAPI dependencies
 "src/**/dependencies.py" = [
+    "TCH",  # Move import into a type-checking block
+]
+
+# ignore checks that are raised only when using Pydantic models
+"src/**/dtos.py" = [
     "TCH",  # Move import into a type-checking block
 ]
 

--- a/src/account/controllers.py
+++ b/src/account/controllers.py
@@ -2,37 +2,43 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from src.account import schemas
+from src.account.dtos import CreateAccountResponse, GetAccountIdResponse
 from src.account.models import Account, PasswordHash
+from src.account.schemas import NewAccount
 from src.profile.models import Profile
+from src.profile.schemas import NewProfile
 
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
     from wlss.account.types import AccountLogin
 
-    from src.account.schemas import NewAccountWithProfile
+    from src.account.dtos import CreateAccountRequest, MatchAccountEmailRequest, MatchAccountLoginRequest
 
 
-async def create_account(request_data: NewAccountWithProfile, session: AsyncSession) -> schemas.AccountWithProfile:
-    account = await Account.create(session, request_data.account)
-    profile = await Profile.create(session, request_data.profile, account_id=account.id)
+async def create_account(request_data: CreateAccountRequest, session: AsyncSession) -> CreateAccountResponse:
+    new_account = NewAccount.from_(request_data.account)
+    account = await Account.create(session, new_account)
+
+    new_profile = NewProfile.from_(request_data.profile)
+    profile = await Profile.create(session, new_profile, account_id=account.id)
+
     await PasswordHash.create(session, request_data.account.password, account_id=account.id)
-    return schemas.AccountWithProfile.model_validate({"account": account, "profile": profile}, from_attributes=True)
+    return CreateAccountResponse.model_validate({"account": account, "profile": profile}, from_attributes=True)
 
 
 async def get_account_id(
     account_login: AccountLogin,
     current_account: Account,  # noqa: ARG001
     session: AsyncSession,
-) -> schemas.AccountId:
+) -> GetAccountIdResponse:
     account = await Account.get_by_login(session, account_login)
-    return schemas.AccountId(id=account.id)
+    return GetAccountIdResponse(id=account.id)
 
 
-async def match_account_login(account_login: schemas.AccountLogin, session: AsyncSession) -> None:
-    await Account.get_by_login(session, account_login.login)
+async def match_account_login(request_data: MatchAccountLoginRequest, session: AsyncSession) -> None:
+    await Account.get_by_login(session, request_data.login)
 
 
-async def match_account_email(account_email: schemas.AccountEmail, session: AsyncSession) -> None:
-    await Account.get_by_email(session, account_email.email)
+async def match_account_email(request_data: MatchAccountEmailRequest, session: AsyncSession) -> None:
+    await Account.get_by_email(session, request_data.email)

--- a/src/account/dtos.py
+++ b/src/account/dtos.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pydantic import Field
+
+from src.account.fields import AccountEmailField, AccountLoginField, AccountPasswordField
+from src.profile.fields import ProfileDescriptionField, ProfileNameField
+from src.shared.fields import IdField, UtcDatetimeField, UuidField
+from src.shared.schemas import Schema
+
+
+class CreateAccountRequest(Schema):
+    account: _Account
+    class _Account(Schema):  # noqa: E301
+        email: AccountEmailField = Field(..., example="john.doe@mail.com")
+        login: AccountLoginField = Field(..., example="john_doe")
+        password: AccountPasswordField = Field(..., example="qwerty123")
+
+    profile: _Profile
+    class _Profile(Schema):  # noqa: E301
+        name: ProfileNameField = Field(..., example="John Doe")
+        description: ProfileDescriptionField | None = Field(None, example="Who da heck is John Doe?")
+
+
+class CreateAccountResponse(Schema):
+    account: _Account
+    class _Account(Schema):  # noqa: E301
+        id: IdField = Field(..., example=42)  # noqa: A003
+        created_at: UtcDatetimeField = Field(..., example="2023-06-17T11:47:02.823Z")
+        email: AccountEmailField = Field(..., example="john.doe@mail.com")
+        login: AccountLoginField = Field(..., example="john_doe")
+
+    profile: _Profile
+    class _Profile(Schema):  # noqa: E301
+        account_id: IdField = Field(..., example=42)
+        avatar_id: UuidField | None = Field(..., example=None)
+        description: ProfileDescriptionField | None = Field(..., example="Who da heck is John Doe?")
+        name: ProfileNameField = Field(..., example="John Doe")
+
+
+class GetAccountIdResponse(Schema):
+    id: IdField = Field(..., example=42)  # noqa: A003
+
+
+class MatchAccountLoginRequest(Schema):
+    login: AccountLoginField = Field(..., example="john_doe")
+
+
+class MatchAccountEmailRequest(Schema):
+    email: AccountEmailField = Field(..., example="john.doe@mail.com")

--- a/src/account/routes.py
+++ b/src/account/routes.py
@@ -5,7 +5,14 @@ from typing import Annotated
 from fastapi import APIRouter, Body, Depends, Path, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.account import controllers, schemas
+from src.account import controllers
+from src.account.dtos import (
+    CreateAccountRequest,
+    CreateAccountResponse,
+    GetAccountIdResponse,
+    MatchAccountEmailRequest,
+    MatchAccountLoginRequest,
+)
 from src.account.fields import AccountLoginField
 from src.account.models import Account
 from src.auth.dependencies import get_account_from_access_token
@@ -20,72 +27,26 @@ router = APIRouter(tags=["account"])
     "/accounts",
     description="Sign Up - create a new account with profile.",
     responses={
-        status.HTTP_201_CREATED: {
-            "description": "New account and profile are created.",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "account": {
-                            "id": 42,
-                            "email": "john.doe@mail.com",
-                            "login": "john_doe",
-                            "created_at": "2023-06-17T11:47:02.823Z",
-                        },
-                        "profile": {
-                            "account_id": 42,
-                            "avatar_id": None,
-                            "description": "Who da heck is John Doe?",
-                            "name": "John Doe",
-                        },
-                    },
-                },
-            },
-        },
+        status.HTTP_201_CREATED: {"description": "New account and profile are created."},
     },
-    response_model=schemas.AccountWithProfile,
     status_code=status.HTTP_201_CREATED,
     summary="Sign Up - create a new account.",
 )
 async def create_account(
-    new_account: Annotated[
-        schemas.NewAccountWithProfile,
-        Body(
-            example={
-                "account": {
-                    "email": "john.doe@mail.com",
-                    "login": "john_doe",
-                    "password": "qwerty123",
-                },
-                "profile": {
-                    "name": "John Doe",
-                    "description": "Who da heck is John Doe?",
-                },
-            },
-        ),
-    ],
+    request_data: Annotated[CreateAccountRequest, Body()],
     session: AsyncSession = Depends(get_session),
-) -> schemas.AccountWithProfile:
-    return await controllers.create_account(new_account, session)
+) -> CreateAccountResponse:
+    return await controllers.create_account(request_data, session)
 
 
 @router.get(
     "/accounts/logins/{account_login}/id",
     description="Get Account Id by login. Account Id is available for every logged in user.",
     responses={
-        status.HTTP_200_OK: {
-            "description": "Account Id returned",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "id": 42,
-                    },
-                },
-            },
-        },
+        status.HTTP_200_OK: {"description": "Account Id returned"},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
     },
-    response_model=schemas.AccountId,
     status_code=status.HTTP_200_OK,
     summary="Get Account Id.",
 )
@@ -93,7 +54,7 @@ async def get_account_id(
     account_login: Annotated[AccountLoginField, Path(example="john_doe")],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
-) -> schemas.AccountId:
+) -> GetAccountIdResponse:
     return await controllers.get_account_id(account_login, current_account, session)
 
 
@@ -101,41 +62,33 @@ async def get_account_id(
     "/accounts/logins/match",
     description="Check if account with provided login exists.",
     responses={
-        status.HTTP_204_NO_CONTENT: {
-            "description": "Account with current login exists.",
-        },
-        status.HTTP_404_NOT_FOUND: {
-            "description": "Account with current login doesn't exist.",
-        },
+        status.HTTP_204_NO_CONTENT: {"description": "Account with current login exists."},
+        status.HTTP_404_NOT_FOUND: {"description": "Account with current login doesn't exist."},
     },
     response_model=None,
     status_code=status.HTTP_204_NO_CONTENT,
     summary="Check login uniqueness.",
 )
 async def match_account_login(
-    account_login: Annotated[schemas.AccountLogin, Body(example={"login": "john_doe"})],
+    request_data: Annotated[MatchAccountLoginRequest, Body()],
     session: AsyncSession = Depends(get_session),
 ) -> None:
-    await controllers.match_account_login(account_login, session)
+    await controllers.match_account_login(request_data, session)
 
 
 @router.post(
     "/accounts/emails/match",
     description="Check if account with provided email exists.",
     responses={
-        status.HTTP_204_NO_CONTENT: {
-            "description": "Account with current email exists.",
-        },
-        status.HTTP_404_NOT_FOUND: {
-            "description": "Account with current email doesn't exist.",
-        },
+        status.HTTP_204_NO_CONTENT: {"description": "Account with current email exists."},
+        status.HTTP_404_NOT_FOUND: {"description": "Account with current email doesn't exist."},
     },
     response_model=None,
     status_code=status.HTTP_204_NO_CONTENT,
     summary="Check email uniqueness.",
 )
 async def match_account_email(
-    account_email: Annotated[schemas.AccountEmail, Body(example={"email": "john.doe@mail.com"})],
+    request_data: Annotated[MatchAccountEmailRequest, Body()],
     session: AsyncSession = Depends(get_session),
 ) -> None:
-    await controllers.match_account_email(account_email, session)
+    await controllers.match_account_email(request_data, session)

--- a/src/account/schemas.py
+++ b/src/account/schemas.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 from src.account.fields import AccountEmailField, AccountLoginField, AccountPasswordField
-from src.profile.schemas import NewProfile, Profile
-from src.shared.fields import IdField, UtcDatetimeField
 from src.shared.schemas import Schema
 
 
@@ -12,33 +10,3 @@ class NewAccount(Schema):
     email: AccountEmailField
     login: AccountLoginField
     password: AccountPasswordField
-
-
-class Account(Schema):
-    id: IdField  # noqa: A003
-
-    created_at: UtcDatetimeField
-    email: AccountEmailField
-    login: AccountLoginField
-
-
-class NewAccountWithProfile(Schema):
-    account: NewAccount
-    profile: NewProfile
-
-
-class AccountWithProfile(Schema):
-    account: Account
-    profile: Profile
-
-
-class AccountId(Schema):
-    id: IdField  # noqa: A003
-
-
-class AccountLogin(Schema):
-    login: AccountLoginField
-
-
-class AccountEmail(Schema):
-    email: AccountEmailField

--- a/src/auth/dtos.py
+++ b/src/auth/dtos.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any, TypeVar
+
+from pydantic import Field, model_validator
+
+from src.account.fields import AccountEmailField, AccountLoginField, AccountPasswordField
+from src.shared.fields import IdField, UuidField
+from src.shared.schemas import Schema
+
+
+DictT = TypeVar("DictT", bound=dict[str, Any])
+
+
+class CreateSessionRequest(Schema):
+    email: AccountEmailField | None = Field(None, example="john.doe@mai.com")
+    login: AccountLoginField | None = Field(None, example="john_doe")
+    password: AccountPasswordField = Field(..., example="qwerty123")
+
+    @model_validator(mode="before")
+    @classmethod  # to silent mypy error, because mypy doesn't recognize model_validator as a classmethod
+    def _require_login_or_email(cls: type[CreateSessionRequest], values: DictT) -> DictT:
+        if not (values.get("login") or values.get("email")):
+            msg = "Either 'login' or 'email' is required."
+            raise ValueError(msg)
+        return values
+
+    @model_validator(mode="before")
+    @classmethod  # to silent mypy error, because mypy doesn't recognize model_validator as a classmethod
+    def _forbid_login_and_email_together(cls: type[CreateSessionRequest], values: DictT) -> DictT:
+        if values.get("login") and values.get("email"):
+            msg = "You cannot use 'login' and 'email' together. Choose one of them."
+            raise ValueError(msg)
+        return values
+
+
+class CreateSessionResponse(Schema):
+    session: _Session
+    class _Session(Schema):  # noqa: E301
+        id: UuidField = Field(..., example="b9dd3a32-aee8-4a6b-a519-def9ca30c9ec")  # noqa: A003
+        account_id: IdField = Field(..., example=42)
+
+    tokens: _Tokens
+    class _Tokens(Schema):  # noqa: E301
+        access_token: str = Field(..., example=(
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6N"
+            "DJ9.YKVpm2zdxup0_ts81Ft4USo-AUMKXBCTfgXtNFbRLlg"
+        ))
+        refresh_token: str = Field(..., example=(
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo0MiwiZGV2aWNlX2lkIj"
+            "oxOCwiZXhwIjoxNjg3MjU2MTMxfQ.GgXVGPV1aE2GjyRWN_IrHaEkZwY_x0gs25lJKtgspX0"
+        ))
+
+
+class RefreshTokensResponse(Schema):
+    access_token: str = Field(..., example=(
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6N"
+        "DJ9.YKVpm2zdxup0_ts81Ft4USo-AUMKXBCTfgXtNFbRLlg"
+    ))
+    refresh_token: str = Field(..., example=(
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo0MiwiZGV2aWNlX2lkIj"
+        "oxOCwiZXhwIjoxNjg3MjU2MTMxfQ.GgXVGPV1aE2GjyRWN_IrHaEkZwY_x0gs25lJKtgspX0"
+    ))

--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -6,8 +6,9 @@ from fastapi import APIRouter, Body, Depends, Path, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.account.models import Account
-from src.auth import controllers, schemas
+from src.auth import controllers
 from src.auth.dependencies import get_account_from_access_token, get_account_from_refresh_token
+from src.auth.dtos import CreateSessionRequest, CreateSessionResponse, RefreshTokensResponse
 from src.shared import swagger as shared_swagger
 from src.shared.database import get_session
 from src.shared.fields import IdField, UuidField
@@ -20,103 +21,29 @@ router = APIRouter(tags=["auth"])
     "/sessions",
     description="Sign In - create new auth session and generate access and refresh tokens for it.",
     responses={
-        status.HTTP_201_CREATED: {
-            "description": "Credentials are valid, new session and tokens are returned.",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "session": {
-                            "id": "b9dd3a32-aee8-4a6b-a519-def9ca30c9ec",
-                            "account_id": 42,
-                        },
-                        "tokens": {
-                            "access_token": (
-                                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6N"
-                                "DJ9.YKVpm2zdxup0_ts81Ft4USo-AUMKXBCTfgXtNFbRLlg"
-                            ),
-                            "refresh_token": (
-                                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo0MiwiZGV2aWNlX2lkIj"
-                                "oxOCwiZXhwIjoxNjg3MjU2MTMxfQ.GgXVGPV1aE2GjyRWN_IrHaEkZwY_x0gs25lJKtgspX0"
-                            ),
-                        },
-                    },
-                },
-            },
-        },
+        status.HTTP_201_CREATED: {"description": "Credentials are valid, new session and tokens are returned."},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
         status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
     },
-    response_model=schemas.SessionWithTokens,
     status_code=status.HTTP_201_CREATED,
     summary="Sign In - create tokens for new session.",
 )
 async def create_session(
-    credentials: Annotated[
-        schemas.Credentials,
-        Body(
-            openapi_examples={
-                "With login": {
-                    "description": "Sign In via login and password.",
-                    "value": {
-                        "login": "john_doe",
-                        "password": "qwerty123",
-                    },
-                },
-                "With email": {
-                    "description": "Sign In via email and password.",
-                    "value": {
-                        "email": "john.doe@mail.com",
-                        "password": "qwerty123",
-                    },
-                },
-                "Invalid - no login, no email": {
-                    "description": "Invalid request - email or login is required.",
-                    "value": {
-                        "password": "qwerty123",
-                    },
-                },
-                "Invalid - both login and email": {
-                    "description": "Invalid request - you can not use login and email together.",
-                    "value": {
-                        "login": "john_doe",
-                        "email": "john.doe@mail.com",
-                        "password": "qwerty123",
-                    },
-                },
-            },
-        ),
-    ],
+    request_data: Annotated[CreateSessionRequest, Body()],
     session: AsyncSession = Depends(get_session),
-) -> schemas.SessionWithTokens:
-    return await controllers.create_session(credentials, session)
+) -> CreateSessionResponse:
+    return await controllers.create_session(request_data, session)
 
 
 @router.post(
     "/accounts/{account_id}/sessions/{session_id}/tokens",
     responses={
-        status.HTTP_201_CREATED: {
-            "description": "New access and refresh tokens are generated and returned.",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "access_token": (
-                            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6N"
-                            "DJ9.YKVpm2zdxup0_ts81Ft4USo-AUMKXBCTfgXtNFbRLlg"
-                        ),
-                        "refresh_token": (
-                            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjo0MiwiZGV2aWNlX2lkIj"
-                            "oxOCwiZXhwIjoxNjg3MjU2MTMxfQ.GgXVGPV1aE2GjyRWN_IrHaEkZwY_x0gs25lJKtgspX0"
-                        ),
-                    },
-                },
-            },
-        },
+        status.HTTP_201_CREATED: {"description": "New access and refresh tokens are generated and returned."},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
         status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
     },
-    response_model=schemas.Tokens,
     status_code=status.HTTP_201_CREATED,
     summary="Generate new access and refresh tokens for particular auth session",
 )
@@ -125,16 +52,14 @@ async def refresh_tokens(
     session_id: Annotated[UuidField, Path(example="b9dd3a32-aee8-4a6b-a519-def9ca30c9ec")],
     current_account: Annotated[Account, Depends(get_account_from_refresh_token)],
     session: AsyncSession = Depends(get_session),
-) -> schemas.Tokens:
+) -> RefreshTokensResponse:
     return await controllers.refresh_tokens(account_id, session_id, current_account, session)
 
 
 @router.delete(
     "/accounts/{account_id}/sessions/{session_id}",
     responses={
-        status.HTTP_204_NO_CONTENT: {
-            "description": "Auth session is removed. User has been signed out.",
-        },
+        status.HTTP_204_NO_CONTENT: {"description": "Auth session is removed. User has been signed out."},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
         status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],

--- a/src/auth/schemas.py
+++ b/src/auth/schemas.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from typing import Any, TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 import jwt
-from pydantic import Field, model_validator
+from pydantic import Field
 from wlss.shared.types import UtcDatetime
 
 from src.account.fields import AccountEmailField, AccountLoginField, AccountPasswordField
@@ -17,45 +17,10 @@ if TYPE_CHECKING:
     from typing import Self
 
 
-DictT = TypeVar("DictT", bound=dict[str, Any])
-
-
 class Credentials(Schema):
     email: AccountEmailField | None = None
     login: AccountLoginField | None = None
     password: AccountPasswordField
-
-    @model_validator(mode="before")
-    @classmethod  # to silent mypy error, because mypy doesn't recognize model_validator as a classmethod
-    def _require_login_or_email(cls: type[Credentials], values: DictT) -> DictT:  # pragma: no cover
-        if not (values.get("login") or values.get("email")):
-            msg = "Either 'login' or 'email' is required."
-            raise ValueError(msg)
-        return values
-
-    @model_validator(mode="before")
-    @classmethod  # to silent mypy error, because mypy doesn't recognize model_validator as a classmethod
-    def _forbid_login_and_email_together(cls: type[Credentials], values: DictT) -> DictT:  # pragma: no cover
-        if values.get("login") and values.get("email"):
-            msg = "You cannot use 'login' and 'email' together. Choose one of them."
-            raise ValueError(msg)
-        return values
-
-
-class Session(Schema):
-    id: UuidField  # noqa: A003
-
-    account_id: IdField
-
-
-class Tokens(Schema):
-    access_token: str
-    refresh_token: str
-
-
-class SessionWithTokens(Schema):
-    session: Session
-    tokens: Tokens
 
 
 class AccessTokenPayload(Schema):

--- a/src/file/dependencies.py
+++ b/src/file/dependencies.py
@@ -9,8 +9,8 @@ from fastapi.exceptions import RequestValidationError
 from pydantic import ValidationError
 
 from src.file.constants import EOF_BYTE, MAX_SIZE, MEGABYTE
+from src.file.dtos import CreateFileRequest
 from src.file.exceptions import FileTooLarge
-from src.file.schemas import NewFile
 
 
 if TYPE_CHECKING:
@@ -25,7 +25,7 @@ async def get_tmp_dir() -> Path:
 async def get_new_file(
     upload_file: UploadFile,
     tmp_dir: Annotated[Path, Depends(get_tmp_dir)],
-) -> AsyncIterator[NewFile]:
+) -> AsyncIterator[CreateFileRequest]:
     filename = Path(upload_file.filename or "")
     extension = filename.suffix.lstrip(".").lower()
 
@@ -33,7 +33,7 @@ async def get_new_file(
     size = _download_file(file_path, upload_file.file)
 
     try:
-        yield NewFile(
+        yield CreateFileRequest(
             extension=extension,
             mime_type=upload_file.content_type,
             name=str(filename),

--- a/src/file/dtos.py
+++ b/src/file/dtos.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.responses import FileResponse
+from pydantic import Field
+
+from src.file.enums import Extension, MimeType
+from src.file.fields import FileSizeField
+from src.shared.fields import UuidField
+from src.shared.schemas import Schema
+
+
+class CreateFileRequest(Schema):
+    extension: Extension = Field(..., example="png")
+    name: str = Field(..., example="image.png")
+    mime_type: MimeType = Field(..., example="image/png")
+    size: FileSizeField = Field(..., example=2048)
+    tmp_file_path: Path
+
+
+class CreateFileResponse(Schema):
+    id: UuidField = Field(..., example="47b3d7a9-d7d3-459a-aac1-155997775a0e")  # noqa: A003
+    extension: Extension = Field(..., example="png")
+    mime_type: MimeType = Field(..., example="image/png")
+    size: FileSizeField = Field(..., example=2048)
+
+
+class GetFileResponse(FileResponse):
+    ...

--- a/src/file/routes.py
+++ b/src/file/routes.py
@@ -4,13 +4,13 @@ import pathlib
 from typing import Annotated
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Path, status
-from fastapi.responses import FileResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.account.models import Account
 from src.auth.dependencies import get_account_from_access_token
-from src.file import controllers, schemas
+from src.file import controllers
 from src.file.dependencies import get_new_file, get_tmp_dir
+from src.file.dtos import CreateFileRequest, CreateFileResponse, GetFileResponse
 from src.shared import swagger as shared_swagger
 from src.shared.database import get_session
 from src.shared.fields import UuidField
@@ -23,32 +23,19 @@ router = APIRouter(tags=["file"])
     "/files",
     description="Upload new file.",
     responses={
-        status.HTTP_200_OK: {
-            "description": "File uploaded, file info returned.",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "id": "47b3d7a9-d7d3-459a-aac1-155997775a0e",
-                        "extension": "png",
-                        "mime_type": "image/png",
-                        "size": 2048,
-                    },
-                },
-            },
-        },
+        status.HTTP_201_CREATED: {"description": "File uploaded, file info returned."},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
     },
-    response_model=schemas.File,
     status_code=status.HTTP_201_CREATED,
     summary="Upload file.",
 )
 async def create_file(
     background_tasks: BackgroundTasks,
-    new_file: Annotated[schemas.NewFile, Depends(get_new_file)],
+    new_file: Annotated[CreateFileRequest, Depends(get_new_file)],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
-) -> schemas.File:
+) -> CreateFileResponse:
     return await controllers.create_file(background_tasks, new_file, current_account, session)
 
 
@@ -56,14 +43,11 @@ async def create_file(
     "/files/{file_id}",
     description="Get (download) uploaded file.",
     responses={
-        status.HTTP_200_OK: {
-            "description": "Uploaded file returned.",
-        },
+        status.HTTP_200_OK: {"description": "Uploaded file returned."},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
         status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
     },
-    response_class=FileResponse,
     status_code=status.HTTP_200_OK,
     summary="Get file.",
 )
@@ -73,5 +57,5 @@ async def get_file(
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     tmp_dir: Annotated[pathlib.Path, Depends(get_tmp_dir)],
     session: AsyncSession = Depends(get_session),
-) -> FileResponse:
+) -> GetFileResponse:
     return await controllers.get_file(background_tasks, file_id, current_account, tmp_dir, session)

--- a/src/file/schemas.py
+++ b/src/file/schemas.py
@@ -4,16 +4,7 @@ from pathlib import Path
 
 from src.file.enums import Extension, MimeType
 from src.file.fields import FileSizeField
-from src.shared.fields import UuidField
 from src.shared.schemas import Schema
-
-
-class File(Schema):
-    id: UuidField  # noqa: A003
-
-    extension: Extension
-    mime_type: MimeType
-    size: FileSizeField
 
 
 class NewFile(Schema):

--- a/src/friendship/dtos.py
+++ b/src/friendship/dtos.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pydantic import Field
+
+from src.friendship.enums import FriendshipRequestStatus
+from src.profile.fields import ProfileDescriptionField, ProfileNameField
+from src.shared.fields import IdField, UtcDatetimeField, UuidField
+from src.shared.schemas import Schema
+
+
+class GetFriendsResponse(Schema):
+    friends: list[_Friend]
+    class _Friend(Schema):  # noqa: E301
+
+        account: _FriendAccount
+        class _FriendAccount(Schema):  # noqa: E301
+            id: IdField = Field(..., example=42)  # noqa: A003
+
+        friendship: _FriendFriendship
+        class _FriendFriendship(Schema):  # noqa: E301
+            created_at: UtcDatetimeField = Field(..., example="2023-06-17T11:47:02.823Z")
+
+        profile: _FriendProfile
+        class _FriendProfile(Schema):  # noqa: E301
+            account_id: IdField = Field(..., example=42)
+            avatar_id: UuidField | None = Field(..., example="0b928aaa-521f-47ec-8be5-396650e2a187")
+            description: ProfileDescriptionField | None = Field(..., example="Who da heck is John Doe?")
+            name: ProfileNameField = Field(..., example="John Doe")
+
+
+class CreateFriendshipRequestRequest(Schema):
+    receiver_id: IdField = Field(..., example=42)
+    sender_id: IdField = Field(..., example=18)
+
+
+class CreateFriendshipRequestResponse(Schema):
+    id: IdField = Field(..., example=11)  # noqa: A003
+    created_at: UtcDatetimeField = Field(..., example="2023-06-17T11:47:02.823Z")
+    receiver_id: IdField = Field(..., example=18)
+    sender_id: IdField = Field(..., example=42)
+    status: FriendshipRequestStatus = Field(..., example="PENDING")
+
+
+class AcceptFriendshipRequestResponse(Schema):
+    friendships: list[_Friendship]
+    class _Friendship(Schema):  # noqa: E301
+        account_id: IdField = Field(..., example=42)
+        created_at: UtcDatetimeField = Field(..., example="2023-06-17T11:47:02.823Z")
+        friend_id: IdField = Field(..., example=18)
+
+
+class RejectFriendshipRequestResponse(Schema):
+    id: IdField = Field(..., example=7)  # noqa: A003
+    created_at: UtcDatetimeField = Field(..., example="2023-06-17T11:47:02.823Z")
+    receiver_id: IdField = Field(..., example=42)
+    sender_id: IdField = Field(..., example=18)
+    status: FriendshipRequestStatus = Field(..., example="REJECTED")
+
+
+class GetFriendshipRequestsResponse(Schema):
+    requests: list[_FriendshipRequest]
+    class _FriendshipRequest(Schema):  # noqa: E301
+        id: IdField = Field(..., example=7)  # noqa: A003
+        created_at: UtcDatetimeField = Field(..., example="2023-06-17T11:47:02.823Z")
+        receiver_id: IdField = Field(..., example=42)
+        sender_id: IdField = Field(..., example=18)
+        status: FriendshipRequestStatus = Field(..., example="PENDING")

--- a/src/friendship/routes.py
+++ b/src/friendship/routes.py
@@ -7,7 +7,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.account.models import Account
 from src.auth.dependencies import get_account_from_access_token
-from src.friendship import controllers, schemas
+from src.friendship import controllers
+from src.friendship.dtos import (
+    AcceptFriendshipRequestResponse,
+    CreateFriendshipRequestRequest,
+    CreateFriendshipRequestResponse,
+    GetFriendshipRequestsResponse,
+    GetFriendsResponse,
+    RejectFriendshipRequestResponse,
+)
 from src.shared import swagger as shared_swagger
 from src.shared.database import get_session
 from src.shared.fields import IdField
@@ -20,48 +28,11 @@ router = APIRouter(tags=["friendship"])
     "/accounts/{account_id}/friends",
     description="Get profile info of friends of particular account",
     responses={
-        status.HTTP_200_OK: {
-            "description": "Profile info for account friends is returned.",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "friends": [
-                            {
-                                "account": {
-                                    "id": 42,
-                                },
-                                "friendship": {
-                                    "created_at": "2023-06-17T11:47:02.823Z",
-                                },
-                                "profile": {
-                                    "name": "John Doe",
-                                    "description": "Who da heck is John Doe?",
-                                    "avatar_id": "0b928aaa-521f-47ec-8be5-396650e2a187",
-                                },
-                            },
-                            {
-                                "account": {
-                                    "id": 18,
-                                },
-                                "friendship": {
-                                    "created_at": "2023-08-07T00:18:21.823Z",
-                                },
-                                "profile": {
-                                    "name": "Alan Fresco",
-                                    "description": "Who da heck is Alan Fresco?",
-                                    "avatar_id": "595f1db3-cdc6-4ef7-bbb4-33c4cedfe172",
-                                },
-                            },
-                        ],
-                    },
-                },
-            },
-        },
+        status.HTTP_200_OK: {"description": "Profile info for account friends is returned."},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
         status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
     },
-    response_model=schemas.Friends,
     status_code=status.HTTP_200_OK,
     summary="Get friends.",
 )
@@ -69,7 +40,7 @@ async def get_friends(
     account_id: Annotated[IdField, Path(example=15)],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
-) -> schemas.Friends:
+) -> GetFriendsResponse:
     return await controllers.get_friends(account_id, current_account, session)
 
 
@@ -77,45 +48,26 @@ async def get_friends(
     "/friendship/requests",
     description="Create new friendship request.",
     responses={
-        status.HTTP_201_CREATED: {
-            "description": "New friendship request is created and returned.",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "id": 11,
-                        "receiver_id": 42,
-                        "sender_id": 18,
-                        "status": "PENDING",
-                        "created_at": "2023-06-17T11:47:02.823Z",
-                    },
-                },
-            },
-        },
+        status.HTTP_201_CREATED: {"description": "New friendship request is created and returned."},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
     },
-    response_model=schemas.FriendshipRequest,
     status_code=status.HTTP_201_CREATED,
     summary="Create friendship request.",
 )
 async def create_friendship_request(
-    new_friendship_request: Annotated[
-        schemas.NewFriendshipRequest,
-        Body(example={"sender_id": 42, "receiver_id": 18}),
-    ],
+    request_data: Annotated[CreateFriendshipRequestRequest, Body()],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
-) -> schemas.FriendshipRequest:
-    return await controllers.create_friendship_request(new_friendship_request, current_account, session)
+) -> CreateFriendshipRequestResponse:
+    return await controllers.create_friendship_request(request_data, current_account, session)
 
 
 @router.delete(
     "/friendship/requests/{request_id}",
     description="Cancel (same as delete) existing friendship request.",
     responses={
-        status.HTTP_204_NO_CONTENT: {
-            "description": "Friendship request has been removed (same as cancelled).",
-        },
+        status.HTTP_204_NO_CONTENT: {"description": "Friendship request has been removed (same as cancelled)."},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
         status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
@@ -136,30 +88,11 @@ async def cancel_friendship_request(
     "/friendship/requests/{request_id}/accepted",
     description="Accept friendship request and create two friendship relations between two accounts.",
     responses={
-        status.HTTP_201_CREATED: {
-            "description": "Friendship request accepted. New friendship relations returned.",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "friendships": [
-                            {
-                                "account_id": 42,
-                                "friend": 18,
-                            },
-                            {
-                                "account_id": 18,
-                                "friend": 42,
-                            },
-                        ],
-                    },
-                },
-            },
-        },
+        status.HTTP_201_CREATED: {"description": "Friendship request accepted. New friendship relations returned."},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
         status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
     },
-    response_model=schemas.Friendships,
     status_code=status.HTTP_201_CREATED,
     summary="Accept friendship request.",
 )
@@ -167,7 +100,7 @@ async def accept_friendship_request(
     request_id: Annotated[IdField, Path(example=42)],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
-) -> schemas.Friendships:
+) -> AcceptFriendshipRequestResponse:
     return await controllers.accept_friendship_request(request_id, current_account, session)
 
 
@@ -177,23 +110,11 @@ async def accept_friendship_request(
     responses={
         status.HTTP_200_OK: {
             "description": "Friendship request is rejected. Updated friendship request info returned.",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "id": 7,
-                        "receiver_id": 42,
-                        "sender_id": 18,
-                        "status": "REJECTED",
-                        "created_at": "2023-06-17T11:47:02.823Z",
-                    },
-                },
-            },
         },
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
         status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
     },
-    response_model=schemas.FriendshipRequest,
     status_code=status.HTTP_200_OK,
     summary="Reject friendship request.",
 )
@@ -201,7 +122,7 @@ async def reject_friendship_request(
     request_id: Annotated[IdField, Path(example=42)],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
-) -> schemas.FriendshipRequest:
+) -> RejectFriendshipRequestResponse:
     return await controllers.reject_friendship_request(request_id, current_account, session)
 
 
@@ -214,41 +135,11 @@ async def reject_friendship_request(
                 "List of friendship requests is returned. "
                 "Requested account may be either in 'receiver_id' or in 'sender_id' field."
             ),
-            "content": {
-                "application/json": {
-                    "example": {
-                        "requests": [
-                            {
-                                "id": 7,
-                                "receiver_id": 42,
-                                "sender_id": 18,
-                                "status": "PENDING",
-                                "created_at": "2023-06-17T11:47:02.823Z",
-                            },
-                            {
-                                "id": 21,
-                                "receiver_id": 10,
-                                "sender_id": 20,
-                                "status": "CANCELED",
-                                "created_at": "2022-01-08T11:47:02.823Z",
-                            },
-                            {
-                                "id": 53,
-                                "receiver_id": 6,
-                                "sender_id": 14,
-                                "status": "ACCEPTED",
-                                "created_at": "2023-03-18T11:47:02.823Z",
-                            },
-                        ],
-                    },
-                },
-            },
         },
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
         status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
     },
-    response_model=schemas.FriendshipRequests,
     status_code=status.HTTP_200_OK,
     summary="Get friendship requests.",
 )
@@ -256,5 +147,5 @@ async def get_friendship_requests(
     account_id: Annotated[IdField, Path(example=42)],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
-) -> schemas.FriendshipRequests:
+) -> GetFriendshipRequestsResponse:
     return await controllers.get_friendship_requests(account_id, current_account, session)

--- a/src/friendship/schemas.py
+++ b/src/friendship/schemas.py
@@ -1,66 +1,9 @@
 from __future__ import annotations
 
-from uuid import UUID
-
-from src.friendship.enums import FriendshipRequestStatus
-from src.profile.fields import ProfileDescriptionField, ProfileNameField
-from src.shared.fields import IdField, UtcDatetimeField
+from src.shared.fields import IdField
 from src.shared.schemas import Schema
-
-
-class NewFriendship(Schema):
-    account_id: IdField
-    friend_id: IdField
-
-
-class Friendship(Schema):
-    account_id: IdField
-    created_at: UtcDatetimeField
-    friend_id: IdField
-
-
-class Friendships(Schema):
-    friendships: list[Friendship]
-
-
-class FriendshipRequest(Schema):
-    id: IdField  # noqa: A003
-
-    created_at: UtcDatetimeField
-    receiver_id: IdField
-    sender_id: IdField
-    status: FriendshipRequestStatus
-
-
-class FriendshipRequests(Schema):
-    requests: list[FriendshipRequest]
 
 
 class NewFriendshipRequest(Schema):
     receiver_id: IdField
     sender_id: IdField
-
-
-class Friend(Schema):
-    account: FriendAccount
-    profile: FriendProfile
-    friendship: FriendFriendship
-
-
-class FriendAccount(Schema):
-    id: IdField  # noqa: A003
-
-
-class FriendProfile(Schema):
-    account_id: IdField
-    avatar_id: UUID | None = None
-    description: ProfileDescriptionField | None
-    name: ProfileNameField
-
-
-class FriendFriendship(Schema):
-    created_at: UtcDatetimeField
-
-
-class Friends(Schema):
-    friends: list[Friend]

--- a/src/profile/controllers.py
+++ b/src/profile/controllers.py
@@ -3,41 +3,35 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from src.account.models import Account
-from src.profile import schemas
+from src.profile.dtos import GetProfileResponse, UpdateProfileResponse
+from src.profile.schemas import ProfileUpdate
 
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
     from wlss.shared.types import Id
 
+    from src.profile.dtos import UpdateProfileRequest
+
 
 async def get_profile(
     account_id: Id,
     current_account: Account,  # noqa: ARG001
     session: AsyncSession,
-) -> schemas.Profile:
+) -> GetProfileResponse:
     account = await Account.get(session, account_id)
     profile = await account.get_profile(session)
-    return schemas.Profile(
-        account_id=account.id,
-        avatar_id=profile.avatar_id,
-        description=profile.description,
-        name=profile.name,
-    )
+    return GetProfileResponse.model_validate(profile, from_attributes=True)
 
 
 async def update_profile(
     account_id: Id,
-    profile_update: schemas.ProfileUpdate,
+    request_data: UpdateProfileRequest,
     current_account: Account,  # noqa: ARG001
     session: AsyncSession,
-) -> schemas.Profile:
+) -> UpdateProfileResponse:
     account = await Account.get(session, account_id)
     profile = await account.get_profile(session)
+    profile_update = ProfileUpdate.from_(request_data)
     profile = await profile.update(session, profile_update)
-    return schemas.Profile(
-        account_id=account.id,
-        avatar_id=profile.avatar_id,
-        description=profile.description,
-        name=profile.name,
-    )
+    return UpdateProfileResponse.model_validate(profile, from_attributes=True)

--- a/src/profile/dtos.py
+++ b/src/profile/dtos.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pydantic import Field
+
+from src.profile.fields import ProfileDescriptionField, ProfileNameField
+from src.shared.fields import IdField, UuidField
+from src.shared.schemas import Schema
+
+
+class GetProfileResponse(Schema):
+    account_id: IdField = Field(..., example=42)
+    avatar_id: UuidField | None = Field(..., example="0b928aaa-521f-47ec-8be5-396650e2a187")
+    description: ProfileDescriptionField | None = Field(..., example="Who da heck is John Doe?")
+    name: ProfileNameField = Field(..., example="John Doe")
+
+
+class UpdateProfileRequest(Schema):
+    avatar_id: UuidField | None = Field(..., example="0b928aaa-521f-47ec-8be5-396650e2a187")
+    description: ProfileDescriptionField | None = Field(..., example="NEW John Doe's profile description.")
+    name: ProfileNameField = Field(..., example="NEW John Doe's profile name.")
+
+
+class UpdateProfileResponse(Schema):
+    account_id: IdField = Field(..., example=42)
+    avatar_id: UuidField | None = Field(..., example="0b928aaa-521f-47ec-8be5-396650e2a187")
+    description: ProfileDescriptionField | None = Field(..., example="NEW John Doe's profile description.")
+    name: ProfileNameField = Field(..., example="NEW John Doe's profile name.")

--- a/src/profile/routes.py
+++ b/src/profile/routes.py
@@ -7,7 +7,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.account.models import Account
 from src.auth.dependencies import get_account_from_access_token
-from src.profile import controllers, schemas
+from src.profile import controllers
+from src.profile.dtos import GetProfileResponse, UpdateProfileRequest, UpdateProfileResponse
 from src.shared import swagger as shared_swagger
 from src.shared.database import get_session
 from src.shared.fields import IdField
@@ -20,24 +21,11 @@ router = APIRouter(tags=["profile"])
     "/accounts/{account_id}/profile",
     description="Get Profile info related to particular user Account.",
     responses={
-        status.HTTP_200_OK: {
-            "description": "Profile info returned.",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "account_id": 42,
-                        "name": "John Doe",
-                        "description": "Who da heck is John Doe?",
-                        "avatar_id": "0b928aaa-521f-47ec-8be5-396650e2a187",
-                    },
-                },
-            },
-        },
+        status.HTTP_200_OK: {"description": "Profile info returned."},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
         status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
     },
-    response_model=schemas.Profile,
     status_code=status.HTTP_200_OK,
     summary="Get Profile info.",
 )
@@ -45,7 +33,7 @@ async def get_profile(
     account_id: Annotated[IdField, Path(example=42)],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
-) -> schemas.Profile:
+) -> GetProfileResponse:
     return await controllers.get_profile(account_id, current_account, session)
 
 
@@ -53,40 +41,18 @@ async def get_profile(
     "/accounts/{account_id}/profile",
     description="Update Profile info.",
     responses={
-        status.HTTP_200_OK: {
-            "description": "Profile info is updated. Profile returned.",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "account_id": 42,
-                        "name": "John Doe",
-                        "description": "Who da heck is John Doe?",
-                        "avatar_id": "0b928aaa-521f-47ec-8be5-396650e2a187",
-                    },
-                },
-            },
-        },
+        status.HTTP_200_OK: {"description": "Profile info is updated. Profile returned."},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
         status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
     },
-    response_model=schemas.Profile,
     status_code=status.HTTP_200_OK,
     summary="Update Profile info.",
 )
 async def update_profile(
     account_id: Annotated[IdField, Path(example=42)],
-    profile_update: Annotated[
-        schemas.ProfileUpdate,
-        Body(
-            example={
-                "name": "John Doe",
-                "description": "Who da heck is John Doe?",
-                "avatar_id": "0b928aaa-521f-47ec-8be5-396650e2a187",
-            },
-        ),
-    ],
+    request_data: Annotated[UpdateProfileRequest, Body()],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
-) -> schemas.Profile:
-    return await controllers.update_profile(account_id, profile_update, current_account, session)
+) -> UpdateProfileResponse:
+    return await controllers.update_profile(account_id, request_data, current_account, session)

--- a/src/profile/schemas.py
+++ b/src/profile/schemas.py
@@ -1,23 +1,13 @@
 from __future__ import annotations
 
-from uuid import UUID
-
 from src.profile.fields import ProfileDescriptionField, ProfileNameField
-from src.shared.fields import IdField, UuidField
+from src.shared.fields import UuidField
 from src.shared.schemas import Schema
 
 
 class NewProfile(Schema):
     name: ProfileNameField
     description: ProfileDescriptionField | None = None
-
-
-class Profile(Schema):
-    account_id: IdField
-
-    avatar_id: UUID | None = None
-    description: ProfileDescriptionField | None = None
-    name: ProfileNameField
 
 
 class ProfileUpdate(Schema):

--- a/src/shared/schemas.py
+++ b/src/shared/schemas.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
+from typing import TypeVar
+
 from pydantic import BaseModel
+
+
+T = TypeVar("T", bound=BaseModel)
 
 
 class Schema(BaseModel):
     """Customized 'BaseModel' class from pydantic."""
+
+    @classmethod
+    def from_(cls: type[T], model: Schema) -> T:
+        return cls.model_validate(model.model_dump())
 
 
 class HTTPError(Schema):

--- a/src/wish/controllers.py
+++ b/src/wish/controllers.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from src.account.models import Account
-from src.wish import schemas
+from src.wish.dtos import (
+    CreateWishBookingResponse,
+    CreateWishResponse,
+    GetAccountWishesResponse,
+    GetWishBookingsResponse,
+    UpdateWishResponse,
+)
 from src.wish.exceptions import (
     CannotCreateWishBookingError,
     CannotCreateWishError,
@@ -13,37 +19,42 @@ from src.wish.exceptions import (
     CannotUpdateWishError,
 )
 from src.wish.models import WishBooking
+from src.wish.schemas import NewWish, NewWishBooking, WishUpdate
 
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
     from wlss.shared.types import Id
 
+    from src.wish.dtos import CreateWishBookingRequest, CreateWishRequest, UpdateWishRequest
+
 
 async def create_wish(
     account_id: Id,
-    new_wish: schemas.NewWish,
+    request_data: CreateWishRequest,
     current_account: Account,
     session: AsyncSession,
-) -> schemas.Wish:
+) -> CreateWishResponse:
     if account_id != current_account.id:
         raise CannotCreateWishError()
+    new_wish = NewWish.from_(request_data)
     wish = await current_account.create_wish(session, new_wish)
-    return schemas.Wish.model_validate(wish, from_attributes=True)
+    return CreateWishResponse.model_validate(wish, from_attributes=True)
 
 
 async def update_wish(
     account_id: Id,
     wish_id: Id,
-    wish_update: schemas.WishUpdate,
+    request_data: UpdateWishRequest,
     current_account: Account,
     session: AsyncSession,
-) -> schemas.Wish:
+) -> UpdateWishResponse:
     if account_id != current_account.id:
         raise CannotUpdateWishError()
     wish = await current_account.get_wish(session, wish_id)
+    wish_update = WishUpdate.from_(request_data)
     await wish.update(session, wish_update)
-    return schemas.Wish.model_validate(wish, from_attributes=True)
+    return UpdateWishResponse.model_validate(wish, from_attributes=True)
 
 
 async def delete_wish(
@@ -62,7 +73,7 @@ async def get_account_wishes(
     account_id: Id,
     current_account: Account,
     session: AsyncSession,
-) -> schemas.Wishes:
+) -> GetAccountWishesResponse:
     account = await Account.get(session, account_id)
     if not (
         account_id == current_account.id
@@ -70,15 +81,16 @@ async def get_account_wishes(
     ):
         raise CannotGetWishesError()
     wishes = await account.get_wishes(session)
-    return schemas.Wishes.model_validate({"wishes": wishes}, from_attributes=True)
+    return GetAccountWishesResponse.model_validate({"wishes": wishes}, from_attributes=True)
 
 
 async def create_wish_booking(
     account_id: Id,
-    new_wish_booking: schemas.NewWishBooking,
+    request_data: CreateWishBookingRequest,
     current_account: Account,
     session: AsyncSession,
-) -> schemas.WishBooking:
+) -> CreateWishBookingResponse:
+    new_wish_booking = NewWishBooking.from_(request_data)
     account = await Account.get(session, account_id)
     if (
         account_id == current_account.id
@@ -88,7 +100,7 @@ async def create_wish_booking(
         raise CannotCreateWishBookingError()
     wish = await account.get_wish(session, new_wish_booking.wish_id)
     wish_booking = await wish.create_booking(session, new_wish_booking.account_id)
-    return schemas.WishBooking.model_validate(wish_booking, from_attributes=True)
+    return CreateWishBookingResponse.model_validate(wish_booking, from_attributes=True)
 
 
 async def get_wish_bookings(
@@ -96,11 +108,11 @@ async def get_wish_bookings(
     wish_ids: list[Id],
     current_account: Account,
     session: AsyncSession,
-) -> schemas.WishBookings:
+) -> GetWishBookingsResponse:
     if account_id == current_account.id:
         raise CannotGetWishBookingsError()
     wish_bookings = await WishBooking.find_by_wish_ids(session, wish_ids)
-    return schemas.WishBookings.model_validate({"wish_bookings": wish_bookings}, from_attributes=True)
+    return GetWishBookingsResponse.model_validate({"wish_bookings": wish_bookings}, from_attributes=True)
 
 
 async def delete_wish_booking(

--- a/src/wish/dtos.py
+++ b/src/wish/dtos.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pydantic import Field
+
+from src.shared.fields import IdField, UtcDatetimeField, UuidField
+from src.shared.schemas import Schema
+from src.wish.fields import WishDescriptionField, WishTitleField
+
+
+class CreateWishRequest(Schema):
+    avatar_id: UuidField | None = Field(..., example="0b928aaa-521f-47ec-8be5-396650e2a187")
+    description: WishDescriptionField = Field(..., example="I'm gonna take my horse to the old town road.")
+    title: WishTitleField = Field(..., example="Horse")
+
+
+class CreateWishResponse(Schema):
+    id: IdField = Field(..., example=17)  # noqa: A003
+    account_id: IdField = Field(..., example=42)
+    avatar_id: UuidField | None = Field(..., example="0b928aaa-521f-47ec-8be5-396650e2a187")
+    created_at: UtcDatetimeField = Field(..., example="2023-06-17T11:47:02.823Z")
+    description: WishDescriptionField = Field(..., example="I'm gonna take my horse to the old town road.")
+    title: WishTitleField = Field(..., example="Horse")
+
+
+class UpdateWishRequest(Schema):
+    avatar_id: UuidField | None = Field(..., example="0b928aaa-521f-47ec-8be5-396650e2a187")
+    description: WishDescriptionField = Field(..., example="I'm gonna take my NEW horse to the old town road.")
+    title: WishTitleField = Field(..., example="NEW Horse")
+
+
+class UpdateWishResponse(Schema):
+    id: IdField = Field(..., example=17)  # noqa: A003
+    account_id: IdField = Field(..., example=42)
+    avatar_id: UuidField | None = Field(..., example="0b928aaa-521f-47ec-8be5-396650e2a187")
+    created_at: UtcDatetimeField = Field(..., example="2023-06-17T11:47:02.823Z")
+    description: WishDescriptionField = Field(..., example="I'm gonna take my NEW horse to the old town road.")
+    title: WishTitleField = Field(..., example="NEW Horse")
+
+
+class GetAccountWishesResponse(Schema):
+    wishes: list[_Wish]
+    class _Wish(Schema):  # noqa: E301
+        id: IdField = Field(..., example=17)  # noqa: A003
+        account_id: IdField = Field(..., example=42)
+        avatar_id: UuidField | None = Field(..., example="0b928aaa-521f-47ec-8be5-396650e2a187")
+        created_at: UtcDatetimeField = Field(..., example="2023-06-17T11:47:02.823Z")
+        description: WishDescriptionField = Field(..., example="I'm gonna take my horse to the old town road.")
+        title: WishTitleField = Field(..., example="Horse")
+
+
+class CreateWishBookingRequest(Schema):
+    account_id: IdField = Field(..., example=42)
+    wish_id: IdField = Field(..., example=17)
+
+
+class CreateWishBookingResponse(Schema):
+    account_id: IdField = Field(..., example=42)
+    created_at: UtcDatetimeField = Field(..., example="2023-06-17T11:47:02.823Z")
+    wish_id: IdField = Field(..., example=17)
+
+
+class GetWishBookingsResponse(Schema):
+    wish_bookings: list[_WishBooking]
+    class _WishBooking(Schema):  # noqa: E301
+        account_id: IdField
+        created_at: UtcDatetimeField
+        wish_id: IdField

--- a/src/wish/routes.py
+++ b/src/wish/routes.py
@@ -10,7 +10,17 @@ from src.auth.dependencies import get_account_from_access_token
 from src.shared import swagger as shared_swagger
 from src.shared.database import get_session
 from src.shared.fields import IdField
-from src.wish import controllers, schemas
+from src.wish import controllers
+from src.wish.dtos import (
+    CreateWishBookingRequest,
+    CreateWishBookingResponse,
+    CreateWishRequest,
+    CreateWishResponse,
+    GetAccountWishesResponse,
+    GetWishBookingsResponse,
+    UpdateWishRequest,
+    UpdateWishResponse,
+)
 
 
 router = APIRouter(tags=["wish"])
@@ -20,100 +30,50 @@ router = APIRouter(tags=["wish"])
     "/accounts/{account_id}/wishes",
     description="Create a new wish for an account.",
     responses={
-        status.HTTP_201_CREATED: {
-            "description": "New wish is created, wish info is returned.",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "id": 17,
-                        "account_id": 42,
-                        "avatar_id": "0b928aaa-521f-47ec-8be5-396650e2a187",
-                        "title": "Horse",
-                        "description": "I'm gonna take my horse to the old town road.",
-                        "created_at": "2023-06-17T11:47:02.823Z",
-                    },
-                },
-            },
-        },
+        status.HTTP_201_CREATED: {"description": "New wish is created, wish info is returned."},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
         status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
     },
-    response_model=schemas.Wish,
     status_code=status.HTTP_201_CREATED,
     summary="Create a wish.",
 )
 async def create_wish(
     account_id: Annotated[IdField, Path(example=42)],
-    new_wish: Annotated[
-        schemas.NewWish,
-        Body(
-            example={
-                "title": "Horse",
-                "description": "I'm gonna take my horse to the old town road.",
-                "avatar_id": "0b928aaa-521f-47ec-8be5-396650e2a187",
-            },
-        ),
-    ],
+    request_data: Annotated[CreateWishRequest, Body()],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
-) -> schemas.Wish:
-    return await controllers.create_wish(account_id, new_wish, current_account, session)
+) -> CreateWishResponse:
+    return await controllers.create_wish(account_id, request_data, current_account, session)
 
 
 @router.put(
     "/accounts/{account_id}/wishes/{wish_id}",
     description="Update particular wish info.",
     responses={
-        status.HTTP_200_OK: {
-            "description": "Wish info is updated. Wish is returned.",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "id": 17,
-                        "account_id": 42,
-                        "avatar_id": "0b928aaa-521f-47ec-8be5-396650e2a187",
-                        "title": "Horse",
-                        "description": "I'm gonna take my horse to the old town road.",
-                        "created_at": "2023-06-17T11:47:02.823Z",
-                    },
-                },
-            },
-        },
+        status.HTTP_200_OK: {"description": "Wish info is updated. Wish is returned."},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
         status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
     },
-    response_model=schemas.Wish,
     status_code=status.HTTP_200_OK,
     summary="Update particular wish.",
 )
 async def update_wish(
     account_id: Annotated[IdField, Path(example=42)],
     wish_id: Annotated[IdField, Path(example=17)],
-    wish_update: Annotated[
-        schemas.WishUpdate,
-        Body(
-            example={
-                "avatar_id": "0b928aaa-521f-47ec-8be5-396650e2a187",
-                "title": "Horse",
-                "description": "I'm gonna take my horse to the old town road.",
-            },
-        ),
-    ],
+    request_data: Annotated[UpdateWishRequest, Body()],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
-) -> schemas.Wish:
-    return await controllers.update_wish(account_id, wish_id, wish_update, current_account, session)
+) -> UpdateWishResponse:
+    return await controllers.update_wish(account_id, wish_id, request_data, current_account, session)
 
 
 @router.delete(
     "/accounts/{account_id}/wishes/{wish_id}",
     description="Delete particular wish and related bookings.",
     responses={
-        status.HTTP_204_NO_CONTENT: {
-            "description": "Wish and related bookings are deleted.",
-        },
+        status.HTTP_204_NO_CONTENT: {"description": "Wish and related bookings are deleted."},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
         status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
@@ -135,38 +95,11 @@ async def delete_wish(
     "/accounts/{account_id}/wishes",
     description="Get wishes owned by particular account",
     responses={
-        status.HTTP_200_OK: {
-            "descriprtion": "Wishes owned by particular account are returned.",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "wishes": [
-                            {
-                                "id": 17,
-                                "account_id": 42,
-                                "avatar_id": "0b928aaa-521f-47ec-8be5-396650e2a187",
-                                "title": "Horse",
-                                "description": "I'm gonna take my horse to the old town road.",
-                                "created_at": "2023-06-17T11:47:02.823Z",
-                            },
-                            {
-                                "id": 21,
-                                "account_id": 42,
-                                "avatar_id": "92f97bc4-c3d3-4980-86c8-0131c1bedffc",
-                                "title": "Sleep",
-                                "description": "I need some sleep. Time to put the old horse down.",
-                                "created_at": "2023-10-11T18:31:42.715Z",
-                            },
-                        ],
-                    },
-                },
-            },
-        },
+        status.HTTP_200_OK: {"descriprtion": "Wishes owned by particular account are returned."},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
         status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
     },
-    response_model=schemas.Wishes,
     status_code=status.HTTP_200_OK,
     summary="Get account wishes.",
 )
@@ -174,7 +107,7 @@ async def get_account_wishes(
     account_id: Annotated[IdField, Path(example=42)],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
-) -> schemas.Wishes:
+) -> GetAccountWishesResponse:
     return await controllers.get_account_wishes(account_id, current_account, session)
 
 
@@ -182,73 +115,32 @@ async def get_account_wishes(
     "/accounts/{account_id}/wishes/{wish_id}/bookings",
     description="Book particular wish for particular account.",
     responses={
-        status.HTTP_201_CREATED: {
-            "description": "Wish booking is created successfully. Booking info returned.",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "account_id": 42,
-                        "wish_id": 17,
-                        "created_at": "2023-06-17T11:47:02.823Z",
-                    },
-                },
-            },
-        },
+        status.HTTP_201_CREATED: {"description": "Wish booking is created successfully. Booking info returned."},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
         status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
     },
-    response_model=schemas.WishBooking,
     status_code=status.HTTP_201_CREATED,
     summary="Book particular wish.",
 )
 async def create_wish_booking(
     account_id: Annotated[IdField, Path(example=42)],
-    new_wish_booking: Annotated[
-        schemas.NewWishBooking,
-        Body(
-            example={
-                "account_id": 42,
-                "wish_id": 17,
-            },
-        ),
-    ],
+    request_data: Annotated[CreateWishBookingRequest, Body()],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
-) -> schemas.WishBooking:
-    return await controllers.create_wish_booking(account_id, new_wish_booking, current_account, session)
+) -> CreateWishBookingResponse:
+    return await controllers.create_wish_booking(account_id, request_data, current_account, session)
 
 
 @router.get(
     "/accounts/{account_id}/wishes/bookings",
     description="Get wish bookings info for particular wishes.",
     responses={
-        status.HTTP_200_OK: {
-            "description": "Wish bookings for requested wishes are returned",
-            "content": {
-                "application/json": {
-                    "example": {
-                        "bookings": [
-                            {
-                                "account_id": 17,
-                                "created_at": "2023-10-11T18:31:42.715Z",
-                                "wish_id": 42,
-                            },
-                            {
-                                "account_id": 21,
-                                "created_at": "2023-06-17T11:47:02.823Z",
-                                "wish_id": 18,
-                            },
-                        ],
-                    },
-                },
-            },
-        },
+        status.HTTP_200_OK: {"description": "Wish bookings for requested wishes are returned"},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
     },
     status_code=status.HTTP_200_OK,
-    response_model=schemas.WishBookings,
     summary="Get wish bookings.",
 )
 async def get_wish_bookings(
@@ -256,7 +148,7 @@ async def get_wish_bookings(
     wish_ids: Annotated[list[IdField], Query(example=[42, 18], alias="wish_id")],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
     session: AsyncSession = Depends(get_session),
-) -> schemas.WishBookings:
+) -> GetWishBookingsResponse:
     """Get wish bookings for particular wishes."""
     return await controllers.get_wish_bookings(account_id, wish_ids, current_account, session)
 
@@ -265,9 +157,7 @@ async def get_wish_bookings(
     "/bookings/{booking_id}",
     description="Delete particular wish booking.",
     responses={
-        status.HTTP_204_NO_CONTENT: {
-            "description": "Wish Booking has been removed.",
-        },
+        status.HTTP_204_NO_CONTENT: {"description": "Wish Booking has been removed."},
         status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
         status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
         status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],

--- a/src/wish/schemas.py
+++ b/src/wish/schemas.py
@@ -1,22 +1,8 @@
 from __future__ import annotations
 
-from src.shared.fields import IdField, UtcDatetimeField, UuidField
+from src.shared.fields import IdField, UuidField
 from src.shared.schemas import Schema
 from src.wish.fields import WishDescriptionField, WishTitleField
-
-
-class Wish(Schema):
-    id: IdField  # noqa: A003
-
-    account_id: IdField
-    avatar_id: UuidField | None = None
-    created_at: UtcDatetimeField
-    description: WishDescriptionField
-    title: WishTitleField
-
-
-class Wishes(Schema):
-    wishes: list[Wish]
 
 
 class NewWish(Schema):
@@ -29,16 +15,6 @@ class WishUpdate(Schema):
     avatar_id: UuidField | None = None
     description: WishDescriptionField
     title: WishTitleField
-
-
-class WishBooking(Schema):
-    account_id: IdField
-    created_at: UtcDatetimeField
-    wish_id: IdField
-
-
-class WishBookings(Schema):
-    wish_bookings: list[WishBooking]
 
 
 class NewWishBooking(Schema):

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -43,6 +43,9 @@ dotenv
 # development (pylint spellcheck)
 dev
 
+# Data Transfer Objects
+dtos
+
 # End Of File
 EOF
 


### PR DESCRIPTION
В процессе работы над изменением архитектуры API основного бэкенда в связи с переходом на BFF, было обнаружено, что переиспользование схем реквестов и респонзов сильно затрудняет изменение апи, а также подвергает приложение к возникновению неожиданного поведения.

Например, если эндпойнт А использует схему `Profile` в качестве схемы респонза, и при этом эндпойнт Б использует ту же самую схему для своих внутренних нужд, то если в рамках работы на внутренностями эндпойнта Б мы решим добавить/убрать какое-либо поле из схемы `Profile`, то это сразу же отразится на выходных данных эндпойнта А. Такое поведение программы конечно же недопустимо, мы должны стараться уменьшит количество таких неожиданностей (а тем более если эти неожиданности касаются API).

В рамках этой задачи необходимо отделить схемы реквестов и респонзов от схем используемых внутри бэкенд сервиса.