### PR TITLE
Сделать Api контекстным менеджером (#202)

### DIFF
--- a/api/account/client.py
+++ b/api/account/client.py
@@ -30,8 +30,7 @@ class Account:
         self._client = client
 
     async def create_account(self: Self, request_data: CreateAccountRequest) -> CreateAccountResponse:
-        async with self._client as client:
-            response = await client.post("/accounts", json=request_data.model_dump())
+        response = await self._client.post("/accounts", json=request_data.model_dump())
         response.raise_for_status()
         assert response.status_code == httpx.codes.CREATED
         return CreateAccountResponse.model_validate(response.json())
@@ -41,8 +40,7 @@ class Account:
         account_id: Id,
         token: str,
     ) -> GetAccountResponse:
-        async with self._client as client:
-            response = await client.get(f"/accounts/{account_id.value}", headers={"Authorization": f"Bearer {token}"})
+        response = await self._client.get(f"/accounts/{account_id.value}", headers={"Authorization": f"Bearer {token}"})
         response.raise_for_status()
         assert response.status_code == httpx.codes.OK
         return GetAccountResponse.model_validate(response.json())
@@ -55,33 +53,30 @@ class Account:
     ) -> GetAccountsResponse:
         account_ids = account_ids or []
         account_logins = account_logins or []
-        async with self._client as client:
-            response = await client.get(
-                "/accounts",
-                params={
-                    "account_id": [str(v.value) for v in account_ids],
-                    "account_login": [v.value for v in account_logins],
-                },
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.get(
+            "/accounts",
+            params={
+                "account_id": [str(v.value) for v in account_ids],
+                "account_login": [v.value for v in account_logins],
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.OK
         return GetAccountsResponse.model_validate(response.json())
 
     async def match_account_login(self: Self, request_data: MatchAccountLoginRequest) -> bool:
-        async with self._client as client:
-            response = await client.post(
-                "/accounts/logins/match",
-                json=request_data.model_dump(),
-            )
+        response = await self._client.post(
+            "/accounts/logins/match",
+            json=request_data.model_dump(),
+        )
         response.raise_for_status()
         return response.status_code == httpx.codes.NO_CONTENT
 
     async def match_account_email(self: Self, request_data: MatchAccountEmailRequest) -> bool:
-        async with self._client as client:
-            response = await client.post(
-                "/accounts/emails/match",
-                json=request_data.model_dump(),
-            )
+        response = await self._client.post(
+            "/accounts/emails/match",
+            json=request_data.model_dump(),
+        )
         response.raise_for_status()
         return response.status_code == httpx.codes.NO_CONTENT

--- a/api/auth/client.py
+++ b/api/auth/client.py
@@ -21,36 +21,32 @@ class Auth:
         self._client = client
 
     async def create_session(self: Self, request_data: CreateSessionRequest) -> CreateSessionResponse:
-        async with self._client as client:
-            response = await client.post("/sessions", json=request_data.model_dump())
+        response = await self._client.post("/sessions", json=request_data.model_dump())
         response.raise_for_status()
         assert response.status_code == httpx.codes.CREATED
         return CreateSessionResponse.model_validate(response.json())
 
     async def refresh_tokens(self: Self, account_id: Id, session_id: UUID, token: str) -> RefreshTokensResponse:
-        async with self._client as client:
-            response = await client.post(
-                f"/accounts/{account_id.value}/sessions/{session_id}/tokens",
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.post(
+            f"/accounts/{account_id.value}/sessions/{session_id}/tokens",
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.CREATED
         return RefreshTokensResponse.model_validate(response.json())
 
     async def delete_session(self: Self, account_id: Id, session_id: UUID, token: str) -> None:
-        async with self._client as client:
-            response = await client.delete(
-                f"/accounts/{account_id.value}/sessions/{session_id}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.delete(
+            f"/accounts/{account_id.value}/sessions/{session_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.NO_CONTENT
 
     async def delete_all_sessions(self: Self, account_id: Id, token: str) -> None:
-        async with self._client as client:
-            response = await client.delete(
-                f"/accounts/{account_id.value}/sessions",
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.delete(
+            f"/accounts/{account_id.value}/sessions",
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.NO_CONTENT

--- a/api/client.py
+++ b/api/client.py
@@ -18,17 +18,27 @@ if TYPE_CHECKING:
     from typing import Any, Self
 
 
-class Api:  # pylint: disable=too-many-instance-attributes
+class Api:
     def __init__(self: Self, app: Callable[..., Any] | None = None, base_url: str = "") -> None:
         self._client = httpx.AsyncClient(app=app, base_url=base_url)
 
-        self._account = Account(self._client)
-        self._auth = Auth(self._client)
-        self._file = File(self._client)
-        self._friendship = Friendship(self._client)
-        self._health = Health(self._client)
-        self._profile = Profile(self._client)
-        self._wish = Wish(self._client)
+    async def __aenter__(self: Self) -> Client:
+        return Client(await self._client.__aenter__())
+
+    async def __aexit__(self: Self, *args: Any, **kwargs: Any) -> None:
+        await self._client.__aexit__(*args, **kwargs)
+
+
+class Client:
+    def __init__(self: Self, connection: httpx.AsyncClient) -> None:
+
+        self._account = Account(connection)
+        self._auth = Auth(connection)
+        self._file = File(connection)
+        self._friendship = Friendship(connection)
+        self._health = Health(connection)
+        self._profile = Profile(connection)
+        self._wish = Wish(connection)
 
     @property
     def account(self: Self) -> Account:

--- a/api/file/client.py
+++ b/api/file/client.py
@@ -21,33 +21,31 @@ class File:
         self._client = client
 
     async def create_file(self: Self, request_data: CreateFileRequest, token: str) -> CreateFileResponse:
-        async with self._client as client:
-            with request_data.tmp_file_path.open("rb") as f:
+        with request_data.tmp_file_path.open("rb") as f:
 
-                response = await client.post(
-                    "/files",
-                    headers={"Authorization": f"Bearer {token}"},
-                    files={"upload_file": (request_data.name, f, request_data.mime_type.value)},
-                )
+            response = await self._client.post(
+                "/files",
+                headers={"Authorization": f"Bearer {token}"},
+                files={"upload_file": (request_data.name, f, request_data.mime_type.value)},
+            )
 
         response.raise_for_status()
         assert response.status_code == httpx.codes.CREATED
         return CreateFileResponse.model_validate(response.json())
 
     async def get_file(self: Self, file_id: UUID, token: str, tmp_file_path: Path) -> GetFileResponse:
-        async with self._client as client:
-            async with client.stream(
-                "GET",
-                f"/files/{file_id}",
-                headers={"Authorization": f"Bearer {token}"},
-            ) as response:
-                if response.is_error:
-                    await response.aread()
-                    response.raise_for_status()
-                assert response.status_code == httpx.codes.OK
-                with tmp_file_path.open("wb") as f:
-                    async for chunk_data in response.aiter_bytes(chunk_size=5 * MEGABYTE):
-                        f.write(chunk_data)
+        async with self._client.stream(
+            "GET",
+            f"/files/{file_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        ) as response:
+            if response.is_error:
+                await response.aread()
+                response.raise_for_status()
+            assert response.status_code == httpx.codes.OK
+            with tmp_file_path.open("wb") as f:
+                async for chunk_data in response.aiter_bytes(chunk_size=5 * MEGABYTE):
+                    f.write(chunk_data)
         return GetFileResponse(
             path=tmp_file_path,
             status_code=response.status_code,

--- a/api/friendship/client.py
+++ b/api/friendship/client.py
@@ -26,11 +26,10 @@ class Friendship:
         self._client = client
 
     async def get_account_friendships(self: Self, account_id: Id, token: str) -> GetAccountFriendshipsResponse:
-        async with self._client as client:
-            response = await client.get(
-                f"/accounts/{account_id.value}/friendships",
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.get(
+            f"/accounts/{account_id.value}/friendships",
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.OK
         return GetAccountFriendshipsResponse.model_validate(response.json())
@@ -40,59 +39,53 @@ class Friendship:
         request_data: CreateFriendshipRequestRequest,
         token: str,
     ) -> CreateFriendshipRequestResponse:
-        async with self._client as client:
-            response = await client.post(
-                "/friendships/requests",
-                json=request_data.model_dump(),
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.post(
+            "/friendships/requests",
+            json=request_data.model_dump(),
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.CREATED
         return CreateFriendshipRequestResponse.model_validate(response.json())
 
     async def cancel_friendship_request(self: Self, request_id: Id, token: str) -> None:
-        async with self._client as client:
-            response = await client.delete(
-                f"/friendships/requests/{request_id.value}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.delete(
+            f"/friendships/requests/{request_id.value}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.NO_CONTENT
 
     async def accept_friendship_request(self: Self, request_id: Id, token: str) -> AcceptFriendshipRequestResponse:
-        async with self._client as client:
-            response = await client.put(
-                f"/friendships/requests/{request_id.value}/accepted",
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.put(
+            f"/friendships/requests/{request_id.value}/accepted",
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         return AcceptFriendshipRequestResponse.model_validate(response.json())
 
     async def reject_friendship_request(self: Self, request_id: Id, token: str) -> RejectFriendshipRequestResponse:
-        async with self._client as client:
-            response = await client.put(
-                f"/friendships/requests/{request_id.value}/rejected",
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.put(
+            f"/friendships/requests/{request_id.value}/rejected",
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.OK
         return RejectFriendshipRequestResponse.model_validate(response.json())
 
     async def get_friendship_requests(self: Self, account_id: Id, token: str) -> GetFriendshipRequestsResponse:
-        async with self._client as client:
-            response = await client.get(
-                f"/accounts/{account_id.value}/friendships/requests",
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.get(
+            f"/accounts/{account_id.value}/friendships/requests",
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.OK
         return GetFriendshipRequestsResponse.model_validate(response.json())
 
     async def delete_friendships(self: Self, account_id: Id, friend_id: Id, token: str) -> None:
-        async with self._client as client:
-            response = await client.delete(
-                f"/accounts/{account_id.value}/friendships/{friend_id.value}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.delete(
+            f"/accounts/{account_id.value}/friendships/{friend_id.value}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.NO_CONTENT

--- a/api/health/client.py
+++ b/api/health/client.py
@@ -16,8 +16,7 @@ class Health:  # pylint: disable=too-few-public-methods
         self._client = client
 
     async def get_health(self: Self) -> HealthResponse:
-        async with self._client as client:
-            response = await client.get("/health")
+        response = await self._client.get("/health")
         response.raise_for_status()
         assert response.status_code == httpx.codes.OK
         return HealthResponse.model_validate(response.json())

--- a/api/profile/client.py
+++ b/api/profile/client.py
@@ -20,11 +20,10 @@ class Profile:
         self._client = client
 
     async def get_profile(self: Self, account_id: Id, token: str) -> GetProfileResponse:
-        async with self._client as client:
-            response = await client.get(
-                f"/accounts/{account_id.value}/profile",
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.get(
+            f"/accounts/{account_id.value}/profile",
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.OK
         return GetProfileResponse.model_validate(response.json())
@@ -35,23 +34,21 @@ class Profile:
         request_data: UpdateProfileRequest,
         token: str,
     ) -> UpdateProfileResponse:
-        async with self._client as client:
-            response = await client.put(
-                f"/accounts/{account_id.value}/profile",
-                json=request_data.model_dump(),
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.put(
+            f"/accounts/{account_id.value}/profile",
+            json=request_data.model_dump(),
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.OK
         return UpdateProfileResponse.model_validate(response.json())
 
     async def get_profiles(self: Self, account_ids: list[Id], token: str) -> GetProfilesResponse:
-        async with self._client as client:
-            response = await client.get(
-                "/profiles",
-                params={"account_id": [account_id.value for account_id in account_ids]},
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.get(
+            "/profiles",
+            params={"account_id": [account_id.value for account_id in account_ids]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.OK
         return GetProfilesResponse.model_validate(response.json())

--- a/api/wish/client.py
+++ b/api/wish/client.py
@@ -31,12 +31,11 @@ class Wish:
         request_data: CreateWishRequest,
         token: str,
     ) -> CreateWishResponse:
-        async with self._client as client:
-            response = await client.post(
-                f"/accounts/{account_id.value}/wishes",
-                json=request_data.model_dump(),
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.post(
+            f"/accounts/{account_id.value}/wishes",
+            json=request_data.model_dump(),
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.CREATED
         return CreateWishResponse.model_validate(response.json())
@@ -48,31 +47,28 @@ class Wish:
         request_data: UpdateWishRequest,
         token: str,
     ) -> UpdateWishResponse:
-        async with self._client as client:
-            response = await client.put(
-                f"/accounts/{account_id.value}/wishes/{wish_id.value}",
-                json=request_data.model_dump(),
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.put(
+            f"/accounts/{account_id.value}/wishes/{wish_id.value}",
+            json=request_data.model_dump(),
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.OK
         return UpdateWishResponse.model_validate(response.json())
 
     async def delete_wish(self: Self, account_id: Id, wish_id: Id, token: str) -> None:
-        async with self._client as client:
-            response = await client.delete(
-                f"/accounts/{account_id.value}/wishes/{wish_id.value}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.delete(
+            f"/accounts/{account_id.value}/wishes/{wish_id.value}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.NO_CONTENT
 
     async def get_account_wishes(self: Self, account_id: Id, token: str) -> GetAccountWishesResponse:
-        async with self._client as client:
-            response = await client.get(
-                f"/accounts/{account_id.value}/wishes",
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.get(
+            f"/accounts/{account_id.value}/wishes",
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.OK
         return GetAccountWishesResponse.model_validate(response.json())
@@ -84,31 +80,28 @@ class Wish:
         request_data: CreateWishBookingRequest,
         token: str,
     ) -> CreateWishBookingResponse:
-        async with self._client as client:
-            response = await client.post(
-                f"/accounts/{account_id.value}/wishes/{wish_id.value}/bookings",
-                json=request_data.model_dump(),
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.post(
+            f"/accounts/{account_id.value}/wishes/{wish_id.value}/bookings",
+            json=request_data.model_dump(),
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.CREATED
         return CreateWishBookingResponse.model_validate(response.json())
 
     async def get_wish_bookings(self: Self, account_id: Id, token: str) -> GetWishBookingsResponse:
-        async with self._client as client:
-            response = await client.get(
-                f"/accounts/{account_id.value}/wishes/bookings",
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.get(
+            f"/accounts/{account_id.value}/wishes/bookings",
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.OK
         return GetWishBookingsResponse.model_validate(response.json())
 
     async def delete_wish_booking(self: Self, account_id: Id, wish_id: Id, booking_id: Id, token: str) -> None:
-        async with self._client as client:
-            response = await client.delete(
-                f"/accounts/{account_id.value}/wishes/{wish_id.value}/bookings/{booking_id.value}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
+        response = await self._client.delete(
+            f"/accounts/{account_id.value}/wishes/{wish_id.value}/bookings/{booking_id.value}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
         response.raise_for_status()
         assert response.status_code == httpx.codes.NO_CONTENT

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,8 @@ async def api(db_empty):
     def override_get_session():
         yield db_empty
     app.dependency_overrides[get_session] = override_get_session
-    return Api(app=app, base_url="http://")
+    async with Api(app=app, base_url="http://") as api:
+        yield api
 
 
 @pytest.fixture

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,6 +1,12 @@
 # This is a whitelist of allowed words for flake8-spellcheck plugin.
 # IMPORTANT: please keep this list alphabetically sorted by whitelisted words
 
+# asynchronous enter
+aenter
+
+# asynchronous exit
+aexit
+
 # asynchronous iteration
 aiter
 


### PR DESCRIPTION
На данный момент, класс `Api` в `api/client.py` не является контекстным менеджером и для отправки запросов, например `api.profiles.get_profile` открывает контекстный менеджер для `httpx.AsyncClient` внутри самой функции запроса (в данном случае внутри `get_profile()`).

Как выяснилось, это накладывает ограничения на количество запросов. А если точнее - то мы не можем отправить больше одного запроса, т.к. контекстный менеджер соединения будет закрыт после первого запроса. Например:
```python
api = Api(...)
api.account.get_account(...)
api.profile.get_profile(...)  # <- тут мы получим ошибку, т.к. контекстный менеджер клиента
                              # был открыт и потом закрыт в первом запросе, поэтому второй
                              # запрос не может его переиспользовать
```

Конечно, такая ситуация нас не устраивает, и мы хотим иметь возможность отправлять несколько запросов используя один и тот же экземпляр `Api(...)`.

В рамках этой задачи необходимо поправить класс `Api` так, чтобы он смог обслуживать несколько запросов, например:
```python
with Api(...) as api:
    api.account.get_account(...)
    api.profile.get_profile(...)  # <- тут нет ошибки
```