### PR TITLE
Увеличить размер загружаемого фала в nginx (#204)

### DIFF
--- a/envs/qa/deploy/nginx/nginx.conf
+++ b/envs/qa/deploy/nginx/nginx.conf
@@ -2,6 +2,8 @@ events {}
 
 http {
 
+    client_max_body_size 10M;
+
     server {
         listen 8080;
         server_name _;


### PR DESCRIPTION
На данный момент nginx не позволяет загружать большие файлы (вроде как загружаются файлы только до 1Mb). В рамках этой задачи необходимо поправить конфигурацию nginx'a так, чтобы можно было загружать файлы до 10Mb включительно.