### PR TITLE
Поправить работу с файлами согласно требованиям фронта (#206)

### DIFF
--- a/api/file/client.py
+++ b/api/file/client.py
@@ -26,19 +26,15 @@ class File:
             response = await self._client.post(
                 "/files",
                 headers={"Authorization": f"Bearer {token}"},
-                files={"upload_file": (request_data.name, f, request_data.mime_type.value)},
+                files={"file": (request_data.name, f, request_data.mime_type.value)},
             )
 
         response.raise_for_status()
         assert response.status_code == httpx.codes.CREATED
         return CreateFileResponse.model_validate(response.json())
 
-    async def get_file(self: Self, file_id: UUID, token: str, tmp_file_path: Path) -> GetFileResponse:
-        async with self._client.stream(
-            "GET",
-            f"/files/{file_id}",
-            headers={"Authorization": f"Bearer {token}"},
-        ) as response:
+    async def get_file(self: Self, file_id: UUID, tmp_file_path: Path) -> GetFileResponse:
+        async with self._client.stream("GET", f"/files/{file_id}") as response:
             if response.is_error:
                 await response.aread()
                 response.raise_for_status()

--- a/api/file/constants.py
+++ b/api/file/constants.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 
 BYTE = 1
-KILOBYTE = 1000 * BYTE
-MEGABYTE = 1000 * KILOBYTE
+KILOBYTE = 1024 * BYTE
+MEGABYTE = 1024 * KILOBYTE
 
 MAX_SIZE = 10 * MEGABYTE
 

--- a/src/file/controllers.py
+++ b/src/file/controllers.py
@@ -47,7 +47,6 @@ async def create_file(
 async def get_file(
     background_tasks: BackgroundTasks,
     file_id: UUID,
-    current_account: Account,  # noqa: ARG001
     tmp_dir: Path,
     session: AsyncSession,
 ) -> GetFileResponse:

--- a/src/file/routes.py
+++ b/src/file/routes.py
@@ -54,8 +54,7 @@ async def create_file(
 async def get_file(
     background_tasks: BackgroundTasks,
     file_id: Annotated[UuidField, Path(example="47b3d7a9-d7d3-459a-aac1-155997775a0e")],
-    current_account: Annotated[Account, Depends(get_account_from_access_token)],
     tmp_dir: Annotated[pathlib.Path, Depends(get_tmp_dir)],
     session: AsyncSession = Depends(get_session),
 ) -> GetFileResponse:
-    return await controllers.get_file(background_tasks, file_id, current_account, tmp_dir, session)
+    return await controllers.get_file(background_tasks, file_id, tmp_dir, session)

--- a/tests/test_file/test_get_file.py
+++ b/tests/test_file/test_get_file.py
@@ -11,7 +11,6 @@ from api.file.dtos import GetFileResponse
 @pytest.mark.anyio
 @pytest.mark.fixtures({
     "api": "api",
-    "access_token": "access_token",
     "db": "db_with_one_file",
     "minio": "minio_with_one_file",
     "tmp_path": "tmp_path",
@@ -21,7 +20,6 @@ async def test_get_file_returns_correct_response(f):
 
     result = await f.api.file.get_file(
         file_id=UUID("4c8a2c85-0fe3-4ab0-b683-96bb1805d370"),
-        token=f.access_token,
         tmp_file_path=tmp_file_path,
     )
 
@@ -32,7 +30,6 @@ async def test_get_file_returns_correct_response(f):
 
 @pytest.mark.anyio
 @pytest.mark.fixtures({
-    "access_token": "access_token",
     "api": "api",
     "db": "db_with_one_account_and_one_session",
     "minio": "minio_with_one_file",
@@ -43,7 +40,6 @@ async def test_get_file_returns_with_nonexistent_file_raises_correct_exception(f
     with pytest.raises(httpx.HTTPError) as exc_info:
         await f.api.file.get_file(
             file_id=UUID("4c8a2c85-0fe3-4ab0-b683-96bb1805d370"),
-            token=f.access_token,
             tmp_file_path=tmp_file_path,
         )
 


### PR DESCRIPTION
По запросу фронта в рамках этой задачи необходимо:
1. Изменить кратность размера файла со степени 10, на степень. Т.к. файлы с ровным количеством байт - 10_000_000 во многих системах отображаются как файлы с размером < 10Mb.
2. Переименовать поле запроса `upload_file` -> `file`.
3. Убрать access токен из эндпойнта на получение файла, т.к. фронт не может его присылать (фронт просто шлёт get запрос из браузера и не может прокидывать туда Authorization хэдер)