### PR TITLE
Добавить значение по умолчанию в get_profiles (#211)

### DIFF
--- a/src/profile/routes.py
+++ b/src/profile/routes.py
@@ -71,8 +71,8 @@ async def update_profile(
     summary="Get profiles.",
 )
 async def get_profiles(
-    account_ids: Annotated[list[IdField], Query(example=[42, 18], alias="account_id")],
     current_account: Annotated[Account, Depends(get_account_from_access_token)],
+    account_ids: Annotated[list[IdField], Query(example=[42, 18], alias="account_id")] = [],  # noqa; B006
     session: AsyncSession = Depends(get_session),
 ) -> GetProfilesResponse:
     return await controllers.get_profiles(account_ids, current_account, session)

--- a/tests/test_profile/test_get_profiles.py
+++ b/tests/test_profile/test_get_profiles.py
@@ -28,3 +28,12 @@ async def test_get_profiles_returns_correct_response(f):
             },
         ],
     }
+
+
+@pytest.mark.anyio
+@pytest.mark.fixtures({"api": "api", "access_token": "access_token", "db": "db_with_three_profiles"})
+async def test_get_profiles_without_account_ids_returns_correct_response(f):
+    result = await f.api.profile.get_profiles(account_ids=[], token=f.access_token)
+
+    assert isinstance(result, GetProfilesResponse)
+    assert result.model_dump() == {"profiles": []}


### PR DESCRIPTION
В рамках (#196) был добавлен эндпойнт `get_profiles`, который принимает айди аккаунтов через query-параметры. Но как оказалось, если вызвать этот эндпойнт с пустым списком `account_ids`
```python
await api.profile.get_profiles(account_ids=[], token=f.access_token)
```
то эндпойнт упадёт с ошибкой, т.к. мы эндпойнт ожидал список айди, но ни один айди не был передан.

Чтобы исправить эту ошибку, в рамках этой задачи необходимо добавить для query-параметра `account_ids` значение по умолчанию - `[]`.