### PR TITLE
Поправить проверку прав в эндпойнтах дружбы (#210)

### DIFF
--- a/src/friendship/exceptions.py
+++ b/src/friendship/exceptions.py
@@ -37,6 +37,14 @@ class CannotDeleteFriendship(NotAllowedException):
     status_code = status.HTTP_403_FORBIDDEN
 
 
+class CannotGetFriendshipRequests(NotAllowedException):
+    action = "Get friendship requests."
+
+    description = "Requested action not allowed."
+    details = "Provided tokens or credentials don't grant you enough access rights."
+    status_code = status.HTTP_403_FORBIDDEN
+
+
 class CannotRejectFriendshipRequest(NotAllowedException):
     action = "Reject friendship request."
 

--- a/tests/test_friendship/conftest.py
+++ b/tests/test_friendship/conftest.py
@@ -42,6 +42,11 @@ async def db_with_two_accounts(db_empty):
         account_id=Id(1),
     )
     session.add(auth_session)
+    auth_session = Session(
+        id=UUID("f83a7e2b-7f2d-4e12-be41-513d950e54d9"),
+        account_id=Id(2),
+    )
+    session.add(auth_session)
     await session.flush()
 
     profiles = [

--- a/tests/test_friendship/test_accept_friendship_request.py
+++ b/tests/test_friendship/test_accept_friendship_request.py
@@ -15,7 +15,11 @@ from tests.utils.mocks.models import __eq__
 
 
 @pytest.mark.anyio
-@pytest.mark.fixtures({"api": "api", "access_token": "access_token", "db": "db_with_one_friendship_request"})
+@pytest.mark.fixtures({
+    "api": "api",
+    "access_token": "access_token",
+    "db": "db_with_friendship_request_from_another_user",
+})
 async def test_accept_friendship_request_returns_correct_response(f):
     result = await f.api.friendship.accept_friendship_request(request_id=Id(1), token=f.access_token)
 
@@ -23,21 +27,25 @@ async def test_accept_friendship_request_returns_correct_response(f):
     assert result.model_dump() == {
         "friendships": [
             {
-                "account_id": 1,
-                "created_at": IsUtcDatetimeSerialized,
-                "friend_id": 2,
-            },
-            {
                 "account_id": 2,
                 "created_at": IsUtcDatetimeSerialized,
                 "friend_id": 1,
+            },
+            {
+                "account_id": 1,
+                "created_at": IsUtcDatetimeSerialized,
+                "friend_id": 2,
             },
         ],
     }
 
 
 @pytest.mark.anyio
-@pytest.mark.fixtures({"access_token": "access_token", "api": "api", "db": "db_with_one_friendship_request"})
+@pytest.mark.fixtures({
+    "access_token": "access_token",
+    "api": "api",
+    "db": "db_with_friendship_request_from_another_user",
+})
 async def test_accept_friendship_request_creates_objects_in_db_correctly(f):
     result = await f.api.friendship.accept_friendship_request(request_id=Id(1), token=f.access_token)  # noqa: F841
 
@@ -62,11 +70,7 @@ async def test_accept_friendship_request_creates_objects_in_db_correctly(f):
 
 
 @pytest.mark.anyio
-@pytest.mark.fixtures({
-    "access_token": "access_token",
-    "api": "api",
-    "db": "db_with_friendship_request_from_another_user",
-})
+@pytest.mark.fixtures({"access_token": "access_token", "api": "api", "db": "db_with_one_friendship_request"})
 async def test_accept_friendship_request_with_friendship_request_from_another_user_raises_correct_exception(f):
     with pytest.raises(httpx.HTTPError) as exc_info:
         await f.api.friendship.accept_friendship_request(request_id=Id(1), token=f.access_token)

--- a/tests/test_friendship/test_get_friendship_requests.py
+++ b/tests/test_friendship/test_get_friendship_requests.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dirty_equals
+import httpx
 import pytest
 from wlss.shared.types import Id
 
@@ -36,4 +37,22 @@ async def test_get_friendship_requests_returns_correct_response(f):
                 "status": FriendshipRequestStatus.PENDING,
             },
         ],
+    }
+
+
+@pytest.mark.anyio
+@pytest.mark.fixtures({
+    "api": "api",
+    "access_token": "access_token",
+    "db": "db_with_three_accounts_and_three_friendship_requests",
+})
+async def test_get_friendship_requests_for_another_account_raises_correct_exception(f):
+    with pytest.raises(httpx.HTTPError) as exc_info:
+        await f.api.friendship.get_friendship_requests(account_id=Id(2), token=f.access_token)
+
+    assert exc_info.value.response.status_code == 403
+    assert exc_info.value.response.json() == {
+        "action": "Get friendship requests.",
+        "description": "Requested action not allowed.",
+        "details": "Provided tokens or credentials don't grant you enough access rights.",
     }

--- a/tests/test_friendship/test_reject_friendship_request.py
+++ b/tests/test_friendship/test_reject_friendship_request.py
@@ -17,7 +17,11 @@ from tests.utils.mocks.models import __eq__
 
 
 @pytest.mark.anyio
-@pytest.mark.fixtures({"api": "api", "access_token": "access_token", "db": "db_with_one_friendship_request"})
+@pytest.mark.fixtures({
+    "api": "api",
+    "access_token": "access_token",
+    "db": "db_with_friendship_request_from_another_user",
+})
 async def test_reject_friendship_request_returns_correct_response(f):
     result = await f.api.friendship.reject_friendship_request(request_id=Id(1), token=f.access_token)
 
@@ -25,14 +29,18 @@ async def test_reject_friendship_request_returns_correct_response(f):
     assert result.model_dump() == {
         "id": dirty_equals.IsInt,
         "created_at": IsUtcDatetimeSerialized,
-        "receiver_id": 2,
-        "sender_id": 1,
+        "receiver_id": 1,
+        "sender_id": 2,
         "status": FriendshipRequestStatus.REJECTED,
     }
 
 
 @pytest.mark.anyio
-@pytest.mark.fixtures({"api": "api", "access_token": "access_token", "db": "db_with_one_friendship_request"})
+@pytest.mark.fixtures({
+    "api": "api",
+    "access_token": "access_token",
+    "db": "db_with_friendship_request_from_another_user",
+})
 async def test_reject_friendship_request_updates_objects_in_db_correctly(f):
     await f.api.friendship.reject_friendship_request(request_id=Id(1), token=f.access_token)
 
@@ -42,8 +50,8 @@ async def test_reject_friendship_request_updates_objects_in_db_correctly(f):
             FriendshipRequest(
                 id=Id(1),
                 created_at=IsUtcDatetime,
-                sender_id=Id(1),
-                receiver_id=Id(2),
+                sender_id=Id(2),
+                receiver_id=Id(1),
                 status=FriendshipRequestStatus.REJECTED,
                 updated_at=IsUtcDatetime,
             ),
@@ -54,7 +62,7 @@ async def test_reject_friendship_request_updates_objects_in_db_correctly(f):
 @pytest.mark.fixtures({
     "access_token": "access_token",
     "api": "api",
-    "db": "db_with_friendship_request_from_another_user",
+    "db": "db_with_one_friendship_request",
 })
 async def test_reject_friendship_request_with_friendship_request_from_another_user_raises_correct_exception(f):
     with pytest.raises(httpx.HTTPError) as exc_info:


### PR DESCRIPTION
В рамках этой задачи необходимо поправить ошибки в проверке прав в эндпойнтах дружбы, а именно:
- `get_friendship_requests` не запрещает получение реквестов другого пользователя (а должен)
- `reject_friendship_request` сверяет текущий аккаунт с аккаунтом отправителя заявки (а должен сверять с аккаунтом получателя)
- `accept_friendship_request` сверяет текущий аккаунт с аккаунтом отправителя заявки (а должен сверять с аккаунтом получателя)