### PR TITLE
Внести правки в создание и получение бронирования и в удаление желаний (#214)

### DIFF
--- a/src/wish/exceptions.py
+++ b/src/wish/exceptions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from fastapi import status
 
-from src.shared.exceptions import NotAllowedException, NotFoundException
+from src.shared.exceptions import BadRequestException, NotAllowedException, NotFoundException
 
 
 class CannotCreateWishError(NotAllowedException):
@@ -59,6 +59,13 @@ class CannotUpdateWishError(NotAllowedException):
     description = "Requested action not allowed."
     details = "Provided tokens or credentials don't grant you enough access rights."
     status_code = status.HTTP_403_FORBIDDEN
+
+
+class DuplicateWishBookingException(BadRequestException):
+    action = "Create wish booking."
+
+    description = "Wish booking already exists."
+    details: str = "Wish already has a booking associated with it."
 
 
 class WishNotFoundError(NotFoundException):

--- a/tests/test_wish/test_create_wish_booking.py
+++ b/tests/test_wish/test_create_wish_booking.py
@@ -33,6 +33,29 @@ async def test_create_wish_booking_returns_correct_response(f):
 
 
 @pytest.mark.anyio
+@pytest.mark.fixtures({
+    "api": "api",
+    "access_token": "access_token",
+    "db": "db_with_two_friend_accounts_and_one_wish_booking",
+})
+async def test_create_wish_booking_with_already_booked_with_raises_correct_exception(f):
+    with pytest.raises(httpx.HTTPError) as exc_info:
+        await f.api.wish.create_wish_booking(
+            account_id=Id(2),
+            wish_id=Id(1),
+            token=f.access_token,
+            request_data=CreateWishBookingRequest.model_validate({"account_id": 1, "wish_id": 1}),
+        )
+
+    assert exc_info.value.response.status_code == 400
+    assert exc_info.value.response.json() == {
+        "action": "Create wish booking.",
+        "description": "Wish booking already exists.",
+        "details": "Wish already has a booking associated with it.",
+    }
+
+
+@pytest.mark.anyio
 @pytest.mark.fixtures({"api": "api", "access_token": "access_token", "db": "db_with_two_friend_accounts_and_one_wish"})
 async def test_create_wish_booking_creates_objects_in_db_correctly(f):
     result = await f.api.wish.create_wish_booking(  # noqa: F841


### PR DESCRIPTION
В процессе интеграции фронта с эндпойнтами бэка было выявлено несколько недостатков в работе эндпойнтов связанных с вишами, а именно:

- желание, забронированное аккаунтом А, можно повторно забронировать аккаунтом Б (и вообще любыми другими аккаунтами)
- получение бронирования не работает если айди желания не совпадает с айди брони :D
- не работает удаление желания, которое уже было забронированно

В рамках этой задачи необходимо исправить недостатки, описанные выше.