### PR TITLE
Добавить эндпойнт поиска профилей (#216)

### DIFF
--- a/api/profile/client.py
+++ b/api/profile/client.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import httpx
 
-from api.profile.dtos import GetProfileResponse, GetProfilesResponse, UpdateProfileResponse
+from api.profile.dtos import GetProfileResponse, GetProfilesResponse, SearchProfilesResponse, UpdateProfileResponse
 
 
 if TYPE_CHECKING:
@@ -52,3 +52,9 @@ class Profile:
         response.raise_for_status()
         assert response.status_code == httpx.codes.OK
         return GetProfilesResponse.model_validate(response.json())
+
+    async def search_profiles(self: Self, token: str) -> SearchProfilesResponse:
+        response = await self._client.post("/profiles/search", headers={"Authorization": f"Bearer {token}"})
+        response.raise_for_status()
+        assert response.status_code == httpx.codes.OK
+        return SearchProfilesResponse.model_validate(response.json())

--- a/api/profile/dtos.py
+++ b/api/profile/dtos.py
@@ -34,3 +34,12 @@ class GetProfilesResponse(Schema):
         avatar_id: UuidField | None = Field(..., example="0b928aaa-521f-47ec-8be5-396650e2a187")
         description: ProfileDescriptionField | None = Field(..., example="Who da heck is John Doe?")
         name: ProfileNameField = Field(..., example="John Doe")
+
+
+class SearchProfilesResponse(Schema):
+    profiles: list[_Profile]
+    class _Profile(Schema):  # noqa: E301
+        account_id: IdField = Field(..., example=42)
+        avatar_id: UuidField | None = Field(..., example="0b928aaa-521f-47ec-8be5-396650e2a187")
+        description: ProfileDescriptionField | None = Field(..., example="Who da heck is John Doe?")
+        name: ProfileNameField = Field(..., example="John Doe")

--- a/src/profile/controllers.py
+++ b/src/profile/controllers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from api.profile.dtos import GetProfileResponse, GetProfilesResponse, UpdateProfileResponse
+from api.profile.dtos import GetProfileResponse, GetProfilesResponse, SearchProfilesResponse, UpdateProfileResponse
 from src.account.models import Account
 from src.profile.models import Profile
 from src.profile.schemas import ProfileUpdate
@@ -45,3 +45,11 @@ async def get_profiles(
 ) -> GetProfilesResponse:
     profiles = await Profile.get_multiple(session, account_ids)
     return GetProfilesResponse.model_validate({"profiles": profiles}, from_attributes=True)
+
+
+async def search_profiles(
+    current_account: Account,  # noqa: ARG001
+    session: AsyncSession,
+) -> SearchProfilesResponse:
+    profiles = await Profile.search_profiles(session)
+    return SearchProfilesResponse.model_validate({"profiles": profiles}, from_attributes=True)

--- a/src/profile/models.py
+++ b/src/profile/models.py
@@ -66,3 +66,9 @@ class Profile(Base):
         query = select(Profile).where(Profile.account_id.in_(account_ids))
         rows = (await session.execute(query)).all()
         return [typing.cast(Profile, row.Profile) for row in rows]
+
+    @staticmethod
+    async def search_profiles(session: AsyncSession) -> list[Profile]:
+        query = select(Profile)
+        rows = (await session.execute(query)).all()
+        return [typing.cast(Profile, row.Profile) for row in rows]

--- a/src/profile/routes.py
+++ b/src/profile/routes.py
@@ -5,7 +5,13 @@ from typing import Annotated
 from fastapi import APIRouter, Body, Depends, Path, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.profile.dtos import GetProfileResponse, GetProfilesResponse, UpdateProfileRequest, UpdateProfileResponse
+from api.profile.dtos import (
+    GetProfileResponse,
+    GetProfilesResponse,
+    SearchProfilesResponse,
+    UpdateProfileRequest,
+    UpdateProfileResponse,
+)
 from api.shared.fields import IdField
 from src.account.models import Account
 from src.auth.dependencies import get_account_from_access_token
@@ -76,3 +82,22 @@ async def get_profiles(
     session: AsyncSession = Depends(get_session),
 ) -> GetProfilesResponse:
     return await controllers.get_profiles(account_ids, current_account, session)
+
+
+@router.post(
+    "/profiles/search",
+    description="Search profiles info by search query.",
+    responses={
+        status.HTTP_200_OK: {"description": "Search result with profiles returned."},
+        status.HTTP_401_UNAUTHORIZED: shared_swagger.responses[status.HTTP_401_UNAUTHORIZED],
+        status.HTTP_403_FORBIDDEN: shared_swagger.responses[status.HTTP_403_FORBIDDEN],
+        status.HTTP_404_NOT_FOUND: shared_swagger.responses[status.HTTP_404_NOT_FOUND],
+    },
+    status_code=status.HTTP_200_OK,
+    summary="Search profiles.",
+)
+async def search_profiles(
+    current_account: Annotated[Account, Depends(get_account_from_access_token)],
+    session: AsyncSession = Depends(get_session),
+) -> SearchProfilesResponse:
+    return await controllers.search_profiles(current_account, session)

--- a/tests/test_profile/test_search_profiles.py
+++ b/tests/test_profile/test_search_profiles.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from api.profile.dtos import SearchProfilesResponse
+
+
+@pytest.mark.anyio
+@pytest.mark.fixtures({"api": "api", "access_token": "access_token", "db": "db_with_three_profiles"})
+async def test_search_profiles_returns_correct_response(f):
+    result = await f.api.profile.search_profiles(token=f.access_token)
+
+    assert isinstance(result, SearchProfilesResponse)
+    assert result.model_dump() == {
+        "profiles": [
+            {
+                "account_id": 1,
+                "avatar_id": None,
+                "description": None,
+                "name": "John Doe",
+            },
+            {
+                "account_id": 2,
+                "avatar_id": None,
+                "description": None,
+                "name": "John Smith",
+            },
+            {
+                "account_id": 3,
+                "avatar_id": None,
+                "description": None,
+                "name": "John Bloggs",
+            },
+        ],
+    }


### PR DESCRIPTION
В процессе интеграции фронта с эндпойнтами бэка стало понятно, что существующий эндпойнт на получение списка профилей `get_profiles` не подходит для случая поиска юзеров, т.к. он принимает список конкретных айди аккаунтов.

Было принято решение не менять эндпойнт `get_profiles` и не заставлять его работать как с айди, так и без айди, т.к. этот эндпойнт хорошо выполняет свою функцию во многих других задачах, где нужно получить информацию о профилях, зная айди аккаунтов. В конце концов, семантика этого эндпойнта была бы немного нарушена, если бы он отдавал два профиля если передали два айди, один профиль если передали один айди, и ВСЕ ПРОФИЛИ если не передали ни одного айди.

Вместо этого мы решили создать отдельный эндпойнт `search_profiles`, который по умолчанию отдаёт профили всех пользователей системы, а также в будущем сможет принимать определённые фильтры, для получения более конкретной выборки.

В рамках этой задачи необходимо добавить эндпойнт `search_profiles`, который (пока что) будет отдавать профили всех пользователей в системе. (В рамках MVP фильтрация профилей по имени и логину будет происходить на фронте.)