### PR TITLE
Добавить удаление старых заявок при создании новой (#229)

### DIFF
--- a/envs/qa/deploy/docker-compose.yml
+++ b/envs/qa/deploy/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       test: [ "CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
       interval: 5s
       retries: 10
+    ports:
+      - 5432:5432
     volumes:
       - postgres:/var/lib/postgresql/data
 

--- a/src/friendship/models.py
+++ b/src/friendship/models.py
@@ -64,6 +64,13 @@ class FriendshipRequest(Base):
         session: AsyncSession,
         new_friendship_request: NewFriendshipRequest,
     ) -> FriendshipRequest:
+        query = delete(FriendshipRequest).where(
+            FriendshipRequest.receiver_id == new_friendship_request.receiver_id,
+            FriendshipRequest.sender_id == new_friendship_request.sender_id,
+        )
+        await session.execute(query)
+        await session.flush()
+
         friendship_request = FriendshipRequest(
             receiver_id=new_friendship_request.receiver_id,
             sender_id=new_friendship_request.sender_id,

--- a/tests/test_friendship/test_create_friendship_request.py
+++ b/tests/test_friendship/test_create_friendship_request.py
@@ -16,7 +16,7 @@ from tests.utils.mocks.models import __eq__
 
 
 @pytest.mark.anyio
-@pytest.mark.fixtures({"api": "api", "access_token": "access_token", "db": "db_with_two_accounts"})
+@pytest.mark.fixtures({"api": "api", "access_token": "access_token", "db": "db_with_one_friendship_request"})
 async def test_create_friendship_request_correct_response(f):
     result = await f.api.friendship.create_friendship_request(
         request_data=CreateFriendshipRequestRequest.model_validate({"receiver_id": 2, "sender_id": 1}),
@@ -34,7 +34,7 @@ async def test_create_friendship_request_correct_response(f):
 
 
 @pytest.mark.anyio
-@pytest.mark.fixtures({"api": "api", "access_token": "access_token", "db": "db_with_two_accounts"})
+@pytest.mark.fixtures({"api": "api", "access_token": "access_token", "db": "db_with_one_friendship_request"})
 async def test_create_friendship_request_creates_objects_in_db_correctly(f):
     result = await f.api.friendship.create_friendship_request(  # noqa: F841
         request_data=CreateFriendshipRequestRequest.model_validate({"receiver_id": 2, "sender_id": 1}),
@@ -56,7 +56,7 @@ async def test_create_friendship_request_creates_objects_in_db_correctly(f):
 
 
 @pytest.mark.anyio
-@pytest.mark.fixtures({"access_token": "access_token", "api": "api", "db": "db_with_two_accounts"})
+@pytest.mark.fixtures({"access_token": "access_token", "api": "api", "db": "db_with_one_friendship_request"})
 async def test_create_friendship_request_for_different_account_ids_in_query_and_token_raises_correct_exception(f):
     with pytest.raises(httpx.HTTPError) as exc_info:
         await f.api.friendship.create_friendship_request(


### PR DESCRIPTION
Т.к. на данный момент при отклонении заявки она не удаляется, а просто переходит в статус `REJECTED`, а также поскольку у нас стоит запрет на существование двух заявок с одинаковыми `sender_id` и `receiver_id`, то необходимо добавить удаление старых заявок при создании новой.

В связи с тем, что для расследования бага с дублирующимися заявками нам впервые пришлось подключиться к бд QA стенда напрямую, было принято решение открыть доступ к бд стенда тоже именно в этой задаче. Аспекты безопасности пока что нас не интересуют, т.к. это всего лишь QA стэнд.