### PR TITLE
Добавить возможность хэширования длинных паролей (#227)

### DIFF
--- a/tests/test_auth/conftest.py
+++ b/tests/test_auth/conftest.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import hashlib
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
@@ -23,7 +25,8 @@ async def db_with_one_account(db_empty):
     session.add(account)
     await session.flush()
 
-    hash_value = bcrypt_cached.hashpw(b"qwerty123", salt=b"$2b$12$K4wmY3GEMQFoMvpuFK.GMu")
+    byte_password = base64.b64encode(hashlib.sha256(b"qwerty123").digest())
+    hash_value = bcrypt_cached.hashpw(byte_password, salt=b"$2b$12$K4wmY3GEMQFoMvpuFK.GMu")
     password_hash = PasswordHash(account_id=Id(1), value=hash_value)
     session.add(password_hash)
     await session.flush()

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -34,6 +34,9 @@ autoincrement
 # auto use (from pytest library)
 autouse
 
+# base64 encoding
+base64
+
 # library for password hashing
 bcrypt
 


### PR DESCRIPTION
Из документации bcrypt:

---

Maximum Password Length

The bcrypt algorithm only handles passwords up to 72 characters, any characters beyond that are ignored. To work around this, a common approach is to hash a password with a cryptographic hash (such as sha256) and then base64 encode it to prevent NULL byte problems before hashing the result with bcrypt:
```python
>>> password = b"an incredibly long password" * 10
>>> hashed = bcrypt.hashpw(
...     base64.b64encode(hashlib.sha256(password).digest()),
...     bcrypt.gensalt()
... )
```

---

В рамках этой задачи необходимо добавить возможность хэширования паролей больше 72 символов по рекомендации доки bcrypt.