### PR TITLE
Добавить ограничение длины имени файла (#226)

### DIFF
--- a/api/file/client.py
+++ b/api/file/client.py
@@ -26,7 +26,7 @@ class File:
             response = await self._client.post(
                 "/files",
                 headers={"Authorization": f"Bearer {token}"},
-                files={"file": (request_data.name, f, request_data.mime_type.value)},
+                files={"file": (request_data.name.value, f, request_data.mime_type.value)},
             )
 
         response.raise_for_status()

--- a/api/file/dtos.py
+++ b/api/file/dtos.py
@@ -6,14 +6,14 @@ from fastapi.responses import FileResponse
 from pydantic import Field
 
 from api.file.enums import Extension, MimeType
-from api.file.fields import FileSizeField
+from api.file.fields import FileNameField, FileSizeField
 from api.shared.fields import UuidField
 from api.shared.schemas import Schema
 
 
 class CreateFileRequest(Schema):
     extension: Extension = Field(..., example="png")
-    name: str = Field(..., example="image.png")
+    name: FileNameField = Field(..., example="image.png")
     mime_type: MimeType = Field(..., example="image/png")
     size: FileSizeField = Field(..., example=2048)
     tmp_file_path: Path

--- a/api/file/fields.py
+++ b/api/file/fields.py
@@ -4,12 +4,25 @@ from typing import Annotated, TYPE_CHECKING
 
 from pydantic import PlainSerializer, PlainValidator, WithJsonSchema
 from pydantic.json_schema import GenerateJsonSchema
-from pydantic_core.core_schema import int_schema
-from wlss.file.types import FileSize
+from pydantic_core.core_schema import int_schema, str_schema
+from wlss.file.types import FileName, FileSize
 
 
 if TYPE_CHECKING:
     from typing import Any
+
+
+FileNameField = Annotated[
+    FileName,
+    PlainValidator(FileName),
+    PlainSerializer(lambda v: v.value, return_type=str),
+    WithJsonSchema(GenerateJsonSchema().generate(
+        str_schema(
+            max_length=FileName.LENGTH_MAX.value,
+            min_length=FileName.LENGTH_MIN.value,
+        ),
+    )),
+]
 
 
 def _validate_file_size(value: Any) -> FileSize:  # noqa: ANN401

--- a/poetry.lock
+++ b/poetry.lock
@@ -2450,8 +2450,8 @@ typing-extensions = "^4.5.0"
 [package.source]
 type = "git"
 url = "https://github.com/week-password/wlss-backend-lib.git"
-reference = "e2c11e344d096579e2582c45fb08007195ebcc8d"
-resolved_reference = "e2c11e344d096579e2582c45fb08007195ebcc8d"
+reference = "ea9c10fab7f3e89b5a9da981a2d153a6729bbc4a"
+resolved_reference = "ea9c10fab7f3e89b5a9da981a2d153a6729bbc4a"
 
 [[package]]
 name = "wrapt"
@@ -2541,4 +2541,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "67f6f90bbfea589541d7fa11957ffa308b524ab8c3c78c5daa3d8aeb9d2ae35a"
+content-hash = "0f7587f3bc2eac7543a11c3703e6e2763287db4ec53abc62fb2e0a3f43f4a52d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ python = "~3.11"
 
 httpx = "^0.24.0"
 pydantic = "^2.5.3"
-wlss = {git = "https://github.com/week-password/wlss-backend-lib.git", rev = "e2c11e344d096579e2582c45fb08007195ebcc8d"}
+wlss = {git = "https://github.com/week-password/wlss-backend-lib.git", rev = "ea9c10fab7f3e89b5a9da981a2d153a6729bbc4a"}
 
 
 [tool.poetry.group.app]

--- a/src/file/columns.py
+++ b/src/file/columns.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
-from wlss.file.types import FileSize
+from wlss.file.types import FileName, FileSize
 
-from src.shared.columns import PositiveIntColumn
+from src.shared.columns import PositiveIntColumn, StrColumn
+
+
+# pylint: disable-next=abstract-method,too-many-ancestors
+class FileNameColumn(StrColumn):
+    type_ = FileName
 
 
 # pylint: disable-next=abstract-method,too-many-ancestors

--- a/src/file/controllers.py
+++ b/src/file/controllers.py
@@ -58,7 +58,7 @@ async def get_file(
         CONFIG.MINIO_ROOT_USER,
         CONFIG.MINIO_ROOT_PASSWORD,
     )
-    file_path = tmp_dir / file.name
+    file_path = tmp_dir / file.name.value
     minio.download_file(file.id, file_path)
 
     background_tasks.add_task(shutil.rmtree, tmp_dir)

--- a/src/file/dependencies.py
+++ b/src/file/dependencies.py
@@ -7,6 +7,7 @@ from typing import Annotated, TYPE_CHECKING
 from fastapi import Depends, File, UploadFile
 from fastapi.exceptions import RequestValidationError
 from pydantic import ValidationError
+from wlss.file.types import FileName
 
 from api.file.constants import EOF_BYTE, MAX_SIZE, MEGABYTE
 from api.file.dtos import CreateFileRequest
@@ -36,7 +37,7 @@ async def get_new_file(
         yield CreateFileRequest(
             extension=extension,
             mime_type=file_request.content_type,
-            name=str(filename),
+            name=FileName(str(filename)),
             size=size,
             tmp_file_path=file_path,
         )

--- a/src/file/models.py
+++ b/src/file/models.py
@@ -4,14 +4,14 @@ import typing
 import uuid
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Enum, select, String, UUID
+from sqlalchemy import Enum, select, UUID
 from sqlalchemy.orm import Mapped, mapped_column
-from wlss.file.types import FileSize
+from wlss.file.types import FileName, FileSize
 from wlss.shared.types import UtcDatetime
 
 from api.file.enums import Extension, MimeType
 from src.file import exceptions
-from src.file.columns import FileSizeColumn
+from src.file.columns import FileNameColumn, FileSizeColumn
 from src.shared.columns import UtcDatetimeColumn
 from src.shared.database import Base
 from src.shared.datetime import utcnow
@@ -32,7 +32,7 @@ class File(Base):
     created_at: Mapped[UtcDatetime] = mapped_column(UtcDatetimeColumn, default=utcnow, nullable=False)
     extension: Mapped[Extension] = mapped_column(Enum(Extension, name="extension_enum"), nullable=False)
     mime_type: Mapped[MimeType] = mapped_column(Enum(MimeType, name="mime_type_enum"), nullable=False)
-    name: Mapped[str] = mapped_column(String, nullable=False)
+    name: Mapped[FileName] = mapped_column(FileNameColumn, nullable=False)
     size: Mapped[FileSize] = mapped_column(FileSizeColumn, nullable=False)
     updated_at: Mapped[UtcDatetime] = mapped_column(UtcDatetimeColumn, default=utcnow, nullable=False, onupdate=utcnow)
 

--- a/src/file/schemas.py
+++ b/src/file/schemas.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 from pathlib import Path
 
 from api.file.enums import Extension, MimeType
-from api.file.fields import FileSizeField
+from api.file.fields import FileNameField, FileSizeField
 from api.shared.schemas import Schema
 
 
 class NewFile(Schema):
 
     extension: Extension
-    name: str
+    name: FileNameField
     mime_type: MimeType
     size: FileSizeField
     tmp_file_path: Path

--- a/tests/test_file/conftest.py
+++ b/tests/test_file/conftest.py
@@ -7,7 +7,7 @@ from uuid import UUID
 import jwt
 import pytest
 from wlss.account.types import AccountEmail, AccountLogin
-from wlss.file.types import FileSize
+from wlss.file.types import FileName, FileSize
 from wlss.shared.types import Id
 
 from api.file.enums import Extension, MimeType
@@ -48,7 +48,7 @@ async def db_with_one_file(db_with_one_account_and_one_session):  # pylint: disa
         id=UUID("4c8a2c85-0fe3-4ab0-b683-96bb1805d370"),
         extension=Extension.PNG,
         mime_type=MimeType.IMAGE_PNG,
-        name="image.png",
+        name=FileName("image.png"),
         size=FileSize(17),
     )
     session.add(file)

--- a/tests/test_file/test_create_file.py
+++ b/tests/test_file/test_create_file.py
@@ -8,7 +8,7 @@ import dirty_equals
 import httpx
 import pytest
 from sqlalchemy import select
-from wlss.file.types import FileSize
+from wlss.file.types import FileName, FileSize
 
 from api.file.dtos import CreateFileRequest, CreateFileResponse
 from api.file.enums import Extension, MimeType
@@ -81,7 +81,7 @@ async def test_create_file_creates_file_in_db_correctly(f):
                 id=dirty_equals.IsUUID(4),
                 extension=Extension.PNG,
                 mime_type=MimeType.IMAGE_PNG,
-                name="image.png",
+                name=FileName("image.png"),
                 size=FileSize(17),
                 updated_at=IsUtcDatetime,
             ),

--- a/tests/test_profile/conftest.py
+++ b/tests/test_profile/conftest.py
@@ -6,7 +6,7 @@ from uuid import UUID
 import jwt
 import pytest
 from wlss.account.types import AccountEmail, AccountLogin
-from wlss.file.types import FileSize
+from wlss.file.types import FileName, FileSize
 from wlss.profile.types import ProfileName
 from wlss.shared.types import Id
 
@@ -51,7 +51,7 @@ async def db_with_one_profile_and_one_file(db_empty):
         id=UUID("2b41c87b-6f06-438b-9933-2a1568cc593b"),
         extension=Extension.PNG,
         mime_type=MimeType.IMAGE_PNG,
-        name="image.png",
+        name=FileName("image.png"),
         size=FileSize(42),
     )
     session.add(file)

--- a/tests/test_wish/conftest.py
+++ b/tests/test_wish/conftest.py
@@ -6,7 +6,7 @@ from uuid import UUID
 import jwt
 import pytest
 from wlss.account.types import AccountEmail, AccountLogin
-from wlss.file.types import FileSize
+from wlss.file.types import FileName, FileSize
 from wlss.shared.types import Id
 from wlss.wish.types import WishDescription, WishTitle
 
@@ -42,7 +42,7 @@ async def db_with_one_account_and_one_file(db_empty):
         id=UUID("0b928aaa-521f-47ec-8be5-396650e2a187"),
         extension=Extension.PNG,
         mime_type=MimeType.IMAGE_PNG,
-        name="image.png",
+        name=FileName("image.png"),
         size=FileSize(17),
     )
     session.add(file)
@@ -92,7 +92,7 @@ async def db_with_two_files_and_one_wish(db_with_one_wish):  # pylint: disable=r
         id=UUID("4b94605b-f5e1-40b1-b9fc-c635c9529e3e"),
         extension=Extension.PNG,
         mime_type=MimeType.IMAGE_PNG,
-        name="new_image.png",
+        name=FileName("new_image.png"),
         size=FileSize(17),
     )
     session.add(file)
@@ -197,7 +197,7 @@ async def db_with_two_accounts_and_two_wishes(  # pylint: disable=redefined-oute
         id=UUID("4b94605b-f5e1-40b1-b9fc-c635c9529e3e"),
         extension=Extension.PNG,
         mime_type=MimeType.IMAGE_PNG,
-        name="new_image.png",
+        name=FileName("new_image.png"),
         size=FileSize(17),
     )
     session.add(file)


### PR DESCRIPTION
После того как была выполнена задача https://github.com/week-password/wlss-backend-lib/issues/18, В рамках этой задачи необходимо интегрировать кастомный тип для имени файла - `FileName` из библиотеки `wlss-backend-lib`.