### PR TITLE
Увеличить таймауты в запросах к API (#234)

### DIFF
--- a/api/client.py
+++ b/api/client.py
@@ -19,8 +19,13 @@ if TYPE_CHECKING:
 
 
 class Api:
-    def __init__(self: Self, app: Callable[..., Any] | None = None, base_url: str = "") -> None:
-        self._client = httpx.AsyncClient(app=app, base_url=base_url)
+    def __init__(
+        self: Self,
+        app: Callable[..., Any] | None = None,
+        base_url: str = "",
+        timeout: httpx.Timeout = httpx.Timeout(30),  # noqa: B008
+    ) -> None:
+        self._client = httpx.AsyncClient(app=app, base_url=base_url, timeout=timeout)
 
     async def __aenter__(self: Self) -> Client:
         return Client(await self._client.__aenter__())


### PR DESCRIPTION
Во время разработки и тестирования было выявлено странное поведение сервисов при попытке загрузить (скачать) картинку.

Если какое-то время не пользоваться сервисом и потом зайти на него, то какое-то время сервис не будет отдавать картинки, т.е. BFF будет возвращать 500 на запрос картинки. Если посмотреть в логи основного бэкенда, то там мы не увидим ни одного лога связанного с файлами - т.е. запрос до основного бэкенда даже не доходит. При этом если посмотреть на логи nginx, который связан с основным бэкендом, то там мы увидим, что nginx ответил 499 на запросы файлов. 499 для nginx это особый код, который обозначает, что клиент преждевременно разорвал соединение. Если я правильно понимаю описание 499 ошибки для nginx, то в нашем случае получается, что BFF не дождался ответа на запрос файла и разорвал соединение по таймауту.

В рамках этой задачи необходимо увеличить таймаут запросов обращающихся к апи основного бэка.

---

Конечно, это не решит проблему того, что после простоя картинки грузятся дольше чем обычно, но эта проблема кажется более сложной и будет решаться в рамках отдельной задачи.