### PR TITLE
Добавить ошибку 400 на попытку использовать файл, который уже используется (#236)

### DIFF
--- a/src/account/models.py
+++ b/src/account/models.py
@@ -15,6 +15,8 @@ from src.account.columns import AccountEmailColumn, AccountLoginColumn
 from src.account.exceptions import AccountNotFoundError, DuplicateAccountException
 from src.auth.exceptions import SessionNotFoundError
 from src.auth.models import Session
+from src.file.exceptions import FileAlreadyInUse
+from src.file.models import File
 from src.friendship.models import Friendship, FriendshipRequest
 from src.profile.models import Profile
 from src.shared.columns import IdColumn, UtcDatetimeColumn
@@ -179,6 +181,9 @@ class Account(Base):
         return [typing.cast(FriendshipRequest, row.FriendshipRequest) for row in rows]
 
     async def create_wish(self: Self, session: AsyncSession, new_wish: schemas.NewWish) -> Wish:
+        if await File.is_already_in_use(session, new_wish.avatar_id):
+            raise FileAlreadyInUse()
+
         wish = Wish(
             account_id=self.id,
             avatar_id=new_wish.avatar_id,

--- a/src/file/exceptions.py
+++ b/src/file/exceptions.py
@@ -2,7 +2,15 @@ from __future__ import annotations
 
 from fastapi import status
 
-from src.shared.exceptions import NotFoundException, TooLargeException
+from src.shared.exceptions import BadRequestException, NotFoundException, TooLargeException
+
+
+class FileAlreadyInUse(BadRequestException):
+    action: str = "Use file"
+
+    description = "Request is not correct."
+    details = "Request contains file that is already in use in somewhere else."
+    status_code = status.HTTP_400_BAD_REQUEST
 
 
 class FileNotFoundError(NotFoundException):  # noqa: A001

--- a/tests/test_profile/conftest.py
+++ b/tests/test_profile/conftest.py
@@ -62,6 +62,52 @@ async def db_with_one_profile_and_one_file(db_empty):
 
 
 @pytest.fixture
+async def db_with_one_profile_and_one_file_already_in_use(db_empty):
+    session = db_empty
+
+    session.add_all([
+        Account(
+            id=Id(1),
+            email=AccountEmail("john.doe@mail.com"),
+            login=AccountLogin("john_doe"),
+        ),
+        Profile(
+            account_id=Id(1),
+            avatar_id=None,
+            description=None,
+            name=ProfileName("John Doe"),
+        ),
+        Session(
+            id=UUID("b9dd3a32-aee8-4a6b-a519-def9ca30c9ec"),
+            account_id=Id(1),
+        ),
+
+
+        Account(
+            id=Id(2),
+            email=AccountEmail("john.smith@mail.com"),
+            login=AccountLogin("john_smith"),
+        ),
+        Profile(
+            account_id=Id(2),
+            avatar_id=UUID("2b41c87b-6f06-438b-9933-2a1568cc593b"),
+            description=None,
+            name=ProfileName("John Smith"),
+        ),
+        File(
+            id=UUID("2b41c87b-6f06-438b-9933-2a1568cc593b"),
+            extension=Extension.PNG,
+            mime_type=MimeType.IMAGE_PNG,
+            name=FileName("image.png"),
+            size=FileSize(42),
+        ),
+    ])
+
+    await session.commit()
+    return session
+
+
+@pytest.fixture
 async def db_with_three_profiles(db_with_one_profile_and_one_file):  # pylint: disable=redefined-outer-name
     session = db_with_one_profile_and_one_file
 

--- a/tests/test_wish/test_update_wish.py
+++ b/tests/test_wish/test_update_wish.py
@@ -71,6 +71,33 @@ async def test_update_wish_updates_objects_in_db_correctly(f):
 
 
 @pytest.mark.anyio
+@pytest.mark.fixtures({
+    "api": "api",
+    "access_token": "access_token",
+    "db": "db_with_one_wish_and_one_file_already_in_use",
+})
+async def test_update_wish_with_file_already_in_use_raises_correct_exception(f):
+    with pytest.raises(httpx.HTTPError) as exc_info:
+        await f.api.wish.update_wish(
+            account_id=Id(1),
+            wish_id=Id(1),
+            token=f.access_token,
+            request_data=UpdateWishRequest.model_validate({
+                "title": "NEW Horse",
+                "description": "I'm gonna take my NEW horse to the old town road.",
+                "avatar_id": "4b94605b-f5e1-40b1-b9fc-c635c9529e3e",
+            }),
+        )
+
+    assert exc_info.value.response.status_code == 400
+    assert exc_info.value.response.json() == {
+        "action": "Use file",
+        "description": "Request is not correct.",
+        "details": "Request contains file that is already in use in somewhere else.",
+    }
+
+
+@pytest.mark.anyio
 @pytest.mark.fixtures({"access_token": "access_token", "api": "api", "db": "db_with_one_account_and_one_file"})
 async def test_update_wish_with_nonexistent_wish_raises_correct_exception(f):
     with pytest.raises(httpx.HTTPError) as exc_info:

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -195,6 +195,9 @@ src
 # standard library
 stdlib
 
+# multiple sub-queries
+subqueries
+
 # table name
 tablename
 


### PR DESCRIPTION
Мы хотим предотвратить использование одного и того же файла больше чем в одном месте. Возможно, это в будущем позволит нам упростить удаление файлов.

В рамках этой задачи необходимо запретить переиспользование файлов на уровне апи и отдавать ошибку 400, если файл уже используется где-либо.